### PR TITLE
Upload area

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weni/unnnic-system",
-  "version": "1.16.11",
+  "version": "1.16.12",
   "main": "./dist/unnnic.common.js",
   "files": [
     "dist/*",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "core-js": "^3.6.5",
+    "mime-types": "^2.1.35",
     "moment": "^2.29.1",
     "v-click-outside": "^3.1.2",
     "vue": "^2.6.11",

--- a/src/components/UploadArea/UploadArea.vue
+++ b/src/components/UploadArea/UploadArea.vue
@@ -70,6 +70,8 @@
 </template>
 
 <script>
+import mime from 'mime-types';
+
 import UnnnicIconSvg from '../Icon.vue';
 import UnnnicImportCard from '../ImportCard/ImportCard.vue';
 
@@ -198,15 +200,17 @@ export default {
       return true;
     },
     validFormat(files) {
-      const formats = this.supportedFormats.replaceAll('.', '').split(',');
+      const formats = this.supportedFormats.split(',').map((format) => format.trim());
 
       const isValid = Array.from(files).find((file) => {
-        // eslint-disable-next-line arrow-body-style
-        const validFormat = formats.find((format) => {
-          return file.type.toLowerCase().includes(format.toLowerCase());
-        });
+        const fileName = file.name.toLowerCase();
+        const fileType = file.type.toLowerCase();
+        const fileExtension = `.${fileName.split('.').pop()}`;
 
-        return validFormat;
+        const isValidFileExtension = formats.includes(fileExtension);
+        const isValidFileType = fileType === mime.lookup(fileName);
+
+        return isValidFileExtension && isValidFileType;
       });
 
       return isValid;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9655,12 +9655,24 @@ mime-db@1.44.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz"
   integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
 mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.27"
   resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz"
   integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
   dependencies:
     mime-db "1.44.0"
+
+mime-types@^2.1.35:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 mime@1.6.0:
   version "1.6.0"


### PR DESCRIPTION
This pull request improves validation of file extensions to ensure greater security in processing files submitted by users. Previous validation based on MIME types compared whether the extension name was included in the MIME type, which was not always reliable. With this update, the "mime-types" library is being used, which provides more reliable information about file types, to check if the extension used has the same type as the corresponding MIME type. Now, both file type and extension are considered, preventing malicious files from being sent disguised with fake extensions.

1. Added _mime-types_ library dependency.
2. Updated the `validFormat` method to use the _mime-types_ library.
3. Validation now includes comparison of allowed file types and extensions.
