### PR TITLE
[Nexus-831] - Add banner alert variation

### DIFF
--- a/src/components/Alert/Alert.vue
+++ b/src/components/Alert/Alert.vue
@@ -111,7 +111,6 @@ export default {
 
     background-color: $unnnic-color-background-snow;
     box-shadow: $unnnic-shadow-level-near;
-    position: fixed;
 
     z-index: 9999;
 

--- a/src/components/Alert/AlertBanner.vue
+++ b/src/components/Alert/AlertBanner.vue
@@ -110,7 +110,7 @@
     }
 
     &__textIcon {
-      margin-right: $unnnic-spacing-ant * 0.9;
+      margin-right: $unnnic-spacing-xs;
     }
   
     &__link {

--- a/src/components/Alert/AlertBanner.vue
+++ b/src/components/Alert/AlertBanner.vue
@@ -1,0 +1,160 @@
+<template>
+    <div :class="['banner-alert', {
+        'banner-alert--banner-danger': type === 'danger',
+        'banner-alert--banner-warning': type === 'warning',
+      }]">
+        <div v-show="text" class="banner-alert__container-text">
+          <unnnic-icon class="banner-alert__textIcon" v-show="isShowTextIcon(type)" :icon="getIconType(type)" size="sm" scheme="neutral-white" />
+          <span class="text" >{{ text }}</span>
+          <a v-if="linkHref" class="banner-alert__link" :href="linkHref" :target="linkTarget">
+            {{ linkText }}
+          </a>
+        </div>
+  
+        <div
+          v-show="showCloseButton"
+          class="banner-alert__close"
+          @click="emitClose"
+        >
+          <unnnic-icon icon="close" size="sm" scheme="neutral-white" />
+        </div>
+      </div>
+  </template>
+  
+  <script>
+  import UnnnicIcon from '../Icon.vue';
+  
+  export default {
+    components: {
+      UnnnicIcon,
+    },
+    methods: {
+      getIconType(type) {
+        if (type === 'danger') return 'block';
+        if (!type.trim()) return 'info'; //check if type is empty or whitespace
+        return type;
+      },
+      isShowTextIcon(type) {
+        return ['danger', 'warning', 'info', ''].includes(type)
+      },
+      emitClose() {
+        this.onClose();
+
+        this.$emit('close');
+      }
+    },
+    props: {
+      version: {
+        type: String,
+        default: '1.0',
+      },
+      text: {
+        type: String,
+        default: null,
+      }, 
+      onClose: {
+        type: Function,
+        default: () => {}
+      },
+      showCloseButton: {
+        type: Boolean,
+        default: false
+      },
+      linkHref: {
+        type: String,
+        default: '',
+      },
+      linkTarget: {
+        type: String,
+        default: '_blank',
+      },
+      linkText: {
+        type: String,
+        default: 'Learn more',
+      },
+      type: {
+        type: String,
+        default: 'info',
+      },
+    }
+  };
+  </script>
+  
+  <style lang="scss" scoped>
+  @import '../../assets/scss/unnnic.scss';
+  
+  .banner-alert {
+    display: flex;
+    align-items: center;
+    text-align: center;
+    justify-content: space-between;
+    margin-bottom: $unnnic-spacing-sm;
+  
+    color: $unnnic-color-neutral-white;
+    font-family: $unnnic-font-family-secondary;
+    font-size: $unnnic-font-size-body-gt;
+    line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
+    font-weight: $unnnic-font-weight-regular;
+    background-color: $unnnic-color-aux-blue-500;
+
+    &__container-text {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      padding: $unnnic-spacing-xs $unnnic-spacing-sm;
+      flex-grow: 1;
+
+      .text {
+        margin-right: $unnnic-spacing-nano;
+      }
+    }
+
+    &__textIcon {
+      margin-right: $unnnic-spacing-ant * 0.9;
+    }
+  
+    &__link {
+      color: inherit;
+      display: block;
+      font-weight: $unnnic-font-weight-bold;
+      text-decoration: underline;
+      text-underline-position: under;
+    }
+  
+    &__close {
+      display: flex;
+      padding: ($unnnic-spacing-xs*1.375) $unnnic-spacing-sm;
+      cursor: pointer;
+      user-select: none;
+      border-left: $unnnic-border-width-thinner solid $unnnic-color-aux-blue-300;
+      &:hover {
+          background-color: $unnnic-color-aux-blue-300;
+        }
+    }
+  
+    &--banner-warning {
+      background-color: $unnnic-color-aux-orange-500;
+  
+      .banner-alert__close {
+        border-left: $unnnic-border-width-thinner solid $unnnic-color-aux-orange-300;
+  
+        &:hover {
+          background-color: $unnnic-color-aux-orange-300;
+        }
+      }
+    }
+  
+    &--banner-danger {
+      background-color: $unnnic-color-aux-red-500;
+  
+      .banner-alert__close {
+        border-left: $unnnic-border-width-thinner solid $unnnic-color-aux-red-300;
+  
+        &:hover {
+          background-color: $unnnic-color-aux-red-300;
+        }
+      }
+    }
+  }
+  </style>
+  

--- a/src/components/Alert/AlertBanner.vue
+++ b/src/components/Alert/AlertBanner.vue
@@ -119,7 +119,7 @@
   
     &__close {
       display: flex;
-      padding: ($unnnic-spacing-xs*1.375) $unnnic-spacing-sm;
+      padding: 11px $unnnic-spacing-sm;
       cursor: pointer;
       user-select: none;
       border-left: $unnnic-border-width-thinner solid $unnnic-color-aux-blue-300;

--- a/src/components/Alert/AlertBanner.vue
+++ b/src/components/Alert/AlertBanner.vue
@@ -1,15 +1,15 @@
 <template>
-    <div :class="['banner-alert', {
+    <section :class="['banner-alert', {
         'banner-alert--banner-danger': type === 'danger',
         'banner-alert--banner-warning': type === 'warning',
       }]">
-        <div v-show="text" class="banner-alert__container-text">
+        <header v-show="text" class="banner-alert__container-text">
           <unnnic-icon class="banner-alert__textIcon" v-show="isShowTextIcon(type)" :icon="getIconType(type)" size="sm" scheme="neutral-white" />
-          <span class="text" >{{ text }}</span>
+          <p class="text" >{{ text }}</p>
           <a v-if="linkHref" class="banner-alert__link" :href="linkHref" :target="linkTarget">
             {{ linkText }}
           </a>
-        </div>
+        </header>
   
         <div
           v-show="showCloseButton"
@@ -18,7 +18,7 @@
         >
           <unnnic-icon icon="close" size="sm" scheme="neutral-white" />
         </div>
-      </div>
+      </section>
   </template>
   
   <script>
@@ -101,7 +101,7 @@
       flex-grow: 1;
 
       .text {
-        margin-right: $unnnic-spacing-nano;
+        margin: 0 $unnnic-spacing-nano 0 0;
       }
     }
 

--- a/src/components/Alert/AlertBanner.vue
+++ b/src/components/Alert/AlertBanner.vue
@@ -80,10 +80,9 @@
   @import '../../assets/scss/unnnic.scss';
   
   .banner-alert {
-    display: flex;
-    align-items: center;
+    display: grid;
+    grid-template-columns: 1fr auto;
     text-align: center;
-    justify-content: space-between;
     margin-bottom: $unnnic-spacing-sm;
   
     color: $unnnic-color-neutral-white;
@@ -119,7 +118,9 @@
   
     &__close {
       display: flex;
-      padding: 11px $unnnic-spacing-sm;
+      align-items: center;
+      max-height: 38px;
+      padding: 0 $unnnic-spacing-sm;
       cursor: pointer;
       user-select: none;
       border-left: $unnnic-border-width-thinner solid $unnnic-color-aux-blue-300;

--- a/src/components/Alert/AlertBanner.vue
+++ b/src/components/Alert/AlertBanner.vue
@@ -44,10 +44,6 @@
       }
     },
     props: {
-      version: {
-        type: String,
-        default: '1.0',
-      },
       text: {
         type: String,
         default: null,

--- a/src/stories/Alert.stories.js
+++ b/src/stories/Alert.stories.js
@@ -1,12 +1,14 @@
 import alertCaller from '../components/Alert/AlertCaller.vue';
 import alert from '../utils/call';
 import unnnicAlert from '../components/Alert/Alert.vue';
+import alertBanner from '../components/Alert/AlertBanner.vue';
 
 export default {
   title: 'example/Alert',
   component: unnnicAlert,
   argTypes: {
     text: { control: { type: 'text' } },
+    showCloseButton: { control: { type: 'boolean' } },
     title: { control: { type: 'text' } },
     closeText: { control: { type: 'text' } },
     scheme: {
@@ -110,6 +112,29 @@ const TemplateWithContainerRef = (args, { argTypes }) => ({
   },
 });
 
+const TemplateBanner = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { alertBanner },
+  template: `
+    <div>
+      <alert-banner v-bind="$props" />
+
+    <pre>
+    Recommended use:
+
+    &lt;unnnic-alert-banner
+      type            String default 'info' ('info', 'warning', 'danger')
+      text            String required
+      showCloseButton Boolean default false
+      @close          Event
+      link-href       String
+      ┠ link-text    String default 'Learn more'
+      ┖ link-target  String default '_blank'
+    /&gt;
+    </pre>
+    </div>`
+});
+
 export const Normal = Template.bind({});
 Normal.args = {
   title: 'Title',
@@ -124,4 +149,10 @@ WithContainerRef.args = {
   text: 'Text',
   icon: 'check-circle-1-1',
   scheme: 'feedback-green',
+};
+
+export const Banner = TemplateBanner.bind({});
+Banner.args = {
+  text: 'Text',
+  showCloseButton: false
 };


### PR DESCRIPTION
## Description

### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
 add a new variation to the alert component

### Summary of Changes
creation of an alert banner with 3 types 'info', 'warning' and 'danger'. Possibility to add links and close button

### Design Files <!--- (If not appropriate, remove this topic) -->
- [Figma Link](https://www.figma.com/file/YbvOpVPUBxTSEzg4J8pXKu/Weni---unnnic?type=design&node-id=19669%3A5663&mode=design&t=DWjCdsP2kq9G73GF-1)

### Demonstration
Final result with variations:

![image](https://github.com/weni-ai/unnnic/assets/34746557/ed44957d-7e71-4b69-86d8-f913cf72cbcf)
![image](https://github.com/weni-ai/unnnic/assets/34746557/ac1500f6-700e-46e5-9138-f9fdc6aae4c0)
![image](https://github.com/weni-ai/unnnic/assets/34746557/eedbae6f-9f02-46ed-9da0-e4e9edf5cd34)
![image](https://github.com/weni-ai/unnnic/assets/34746557/f1540f49-306a-435a-8b32-684be27ab7d2)
![image](https://github.com/weni-ai/unnnic/assets/34746557/3b5d2a52-d49c-4153-8d75-e718c536526c)
