### PR TITLE
[ENGAGE-912] - Vue 3 import of icons at unnnic components

### DIFF
--- a/src/components/Accordion/Accordion.vue
+++ b/src/components/Accordion/Accordion.vue
@@ -5,7 +5,7 @@
     class="unnnic-accordion"
   >
     <div class="header">
-      <UnnnicIconSvg
+      <UnnnicIcon
         :icon="open ? 'subtract-circle-1' : 'add-circle-1'"
         scheme="neutral-clean"
         size="md"
@@ -32,11 +32,11 @@
 </template>
 
 <script>
-import unnnicIconSvg from '../Icon.vue';
+import UnnnicIcon from '../Icon.vue';
 
 export default {
   components: {
-    unnnicIconSvg,
+    UnnnicIcon,
   },
 
   props: {

--- a/src/components/Alert/Alert.vue
+++ b/src/components/Alert/Alert.vue
@@ -3,7 +3,7 @@
     v-if="version === '1.0'"
     :class="['unnnic-alert', `unnnic-alert-position--${position}`]"
   >
-    <UnnnicIconSvg
+    <UnnnicIcon
       :icon="icon"
       :scheme="scheme"
       size="sm"
@@ -23,7 +23,7 @@
     >
       {{ closeText.toUpperCase() }}
     </div>
-    <UnnnicIconSvg
+    <UnnnicIcon
       v-else
       clickable
       icon="close-1"
@@ -41,13 +41,13 @@
 </template>
 
 <script>
-import unnnicIconSvg from '../Icon.vue';
+import UnnnicIcon from '../Icon.vue';
 import Version1dot1 from './Version1dot1.vue';
 
 export default {
   name: 'unnnicAlert',
   components: {
-    unnnicIconSvg,
+    UnnnicIcon,
     Version1dot1,
   },
   props: {

--- a/src/components/Banner/InfoBanner.vue
+++ b/src/components/Banner/InfoBanner.vue
@@ -15,7 +15,7 @@
       <div class="unnnic-banner-info__title">{{ thirdTitle }}</div>
       <div class="unnnic-banner-info__description">{{ thirdDescription }}</div>
       <div class="unnnic-banner-info__rating">
-        <UnnnicIconSvg
+        <UnnnicIcon
           :key="index"
           v-for="index in 5"
           @click="emitRatingAction(index)"
@@ -35,11 +35,11 @@
 </template>
 
 <script>
-import UnnnicIconSvg from '../Icon.vue';
+import UnnnicIcon from '../Icon.vue';
 
 export default {
   name: 'unnnic-banner',
-  components: { UnnnicIconSvg },
+  components: { UnnnicIcon },
   props: {
     firstTitle: {
       type: String,

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -11,7 +11,7 @@
       float ? `unnnic-button--float` : null,
     ]"
   >
-    <UnnnicIconSvg
+    <UnnnicIcon
       v-if="loading"
       icon="loading-circle-1"
       :scheme="iconScheme"
@@ -21,7 +21,7 @@
       :next="next"
     />
 
-    <UnnnicIconSvg
+    <UnnnicIcon
       v-if="iconLeft"
       :icon="iconLeft"
       :scheme="iconScheme"
@@ -31,7 +31,7 @@
       :next="next"
     />
 
-    <UnnnicIconSvg
+    <UnnnicIcon
       v-if="iconCenter"
       :icon="iconCenter"
       :scheme="iconScheme"
@@ -48,7 +48,7 @@
       <slot /> {{ text }}
     </span>
 
-    <UnnnicIconSvg
+    <UnnnicIcon
       v-if="iconRight"
       :icon="iconRight"
       :scheme="iconScheme"
@@ -61,11 +61,11 @@
 </template>
 
 <script>
-import UnnnicIconSvg from '../Icon.vue';
+import UnnnicIcon from '../Icon.vue';
 
 export default {
   components: {
-    UnnnicIconSvg,
+    UnnnicIcon,
   },
   props: {
     size: {

--- a/src/components/Card/BlankCard.vue
+++ b/src/components/Card/BlankCard.vue
@@ -6,7 +6,7 @@
     }"
   >
     <div class="unnnic-card-blank__content">
-      <UnnnicIconSvg
+      <UnnnicIcon
         :icon="icon"
         scheme="neutral-clean"
         class="unnnic-card-blank__content__icon"
@@ -19,12 +19,12 @@
 </template>
 
 <script>
-import UnnnicIconSvg from '../Icon.vue';
+import UnnnicIcon from '../Icon.vue';
 
 export default {
   name: 'unnnic-card',
   components: {
-    UnnnicIconSvg,
+    UnnnicIcon,
   },
   props: {
     text: {

--- a/src/components/Card/ContentCard.vue
+++ b/src/components/Card/ContentCard.vue
@@ -12,7 +12,7 @@
         enabled && 'unnnic-card-content__icon--disabled',
       ]"
     >
-      <UnnnicIconSvg
+      <UnnnicIcon
         :icon="icon"
         scheme="neutral-cloudy"
         size="sm"
@@ -28,12 +28,12 @@
 </template>
 
 <script>
-import UnnnicIconSvg from '../Icon.vue';
+import UnnnicIcon from '../Icon.vue';
 
 export default {
   name: 'unnnic-card',
   components: {
-    UnnnicIconSvg,
+    UnnnicIcon,
   },
   props: {
     title: {

--- a/src/components/Card/MarketplaceCard.vue
+++ b/src/components/Card/MarketplaceCard.vue
@@ -28,7 +28,7 @@
         v-if="typeAction === 'add'"
         class="unnnic-card-marketplace__content__rating"
       >
-        <UnnnicIconSvg
+        <UnnnicIcon
           class="unnnic-card-marketplace__content__rating__star"
           scheme="feedback-yellow"
           icon="rating-star-1"
@@ -46,11 +46,11 @@
 </template>
 
 <script>
-import UnnnicIconSvg from '../Icon.vue';
+import UnnnicIcon from '../Icon.vue';
 
 export default {
   name: 'unnnic-card',
-  components: { UnnnicIconSvg },
+  components: { UnnnicIcon },
   props: {
     title: {
       type: String,

--- a/src/components/Carousel/TagCarousel.vue
+++ b/src/components/Carousel/TagCarousel.vue
@@ -4,7 +4,7 @@
       class="unnnic-card-tag-carousel__button unnnic-card-tag-carousel__button--left"
     >
       <div class="unnnic-card-tag-carousel__button__icon">
-        <UnnnicIconSvg
+        <UnnnicIcon
           icon="arrow-left-1-1"
           size="sm"
           @click="previous()"
@@ -46,7 +46,7 @@
         v-show="hasNext"
       />
       <div class="unnnic-card-tag-carousel__button__icon">
-        <UnnnicIconSvg
+        <UnnnicIcon
           icon="arrow-right-1-1"
           @click="next()"
           size="sm"
@@ -60,7 +60,7 @@
 
 <script>
 import UnnnicTag from '../Tag/Tag.vue';
-import UnnnicIconSvg from '../Icon.vue';
+import UnnnicIcon from '../Icon.vue';
 
 export default {
   name: 'unnnic-tag-carousel',
@@ -73,7 +73,7 @@ export default {
   },
   components: {
     UnnnicTag,
-    UnnnicIconSvg,
+    UnnnicIcon,
   },
   props: {
     modelValue: {

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -1,7 +1,7 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <template>
   <div class="unnnic-checkbox-wrapper">
-    <UIcon
+    <UnnnicIcon
       class="unnnic-checkbox"
       :class="{ disabled }"
       :icon="icon"
@@ -25,7 +25,7 @@
 </template>
 
 <script>
-import uIcon from '../Icon.vue';
+import UnnnicIcon from '../Icon.vue';
 
 export default {
   model: {
@@ -60,7 +60,7 @@ export default {
   },
 
   components: {
-    uIcon,
+    UnnnicIcon,
   },
 
   computed: {

--- a/src/components/Flag.vue
+++ b/src/components/Flag.vue
@@ -1,5 +1,5 @@
 <template>
-  <UnnnicIconSvg
+  <UnnnicIcon
     :icon="name"
     :size="size"
   />
@@ -8,12 +8,12 @@
 <script>
 /* eslint-disable global-require */
 /* eslint-disable vue/multi-word-component-names */
-import UnnnicIconSvg from './Icon.vue';
+import UnnnicIcon from './Icon.vue';
 
 export default {
   name: 'Flag',
   components: {
-    UnnnicIconSvg,
+    UnnnicIcon,
   },
   props: {
     code: {

--- a/src/components/Icon.vue
+++ b/src/components/Icon.vue
@@ -36,9 +36,9 @@
 <script>
 import icons from '../utils/icons';
 import OldIconsMap from './Icon/OldIconsMap.json';
-
+/* eslint-disable vue/multi-word-component-names */
 export default {
-  name: 'uIcon',
+  name: 'Icon',
   props: {
     filled: {
       type: Boolean,

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -19,7 +19,7 @@
               v-if="closeIcon"
               class="unnnic-modal-container-background-body-close_icon"
             >
-              <UnnnicIconSvg
+              <UnnnicIcon
                 icon="close-1"
                 scheme="neutral-dark"
                 size="sm"
@@ -43,7 +43,7 @@
                   : 'unnnic-modal-container-background-body-spacing_header',
               ]"
             >
-              <UnnnicIconSvg
+              <UnnnicIcon
                 :scheme="scheme"
                 :icon="modalIcon"
                 size="xl"
@@ -80,12 +80,12 @@
 </template>
 
 <script>
-import UnnnicIconSvg from '../Icon.vue';
+import UnnnicIcon from '../Icon.vue';
 
 export default {
   name: 'unnnic-modal',
   components: {
-    UnnnicIconSvg,
+    UnnnicIcon,
   },
   props: {
     text: {

--- a/src/components/Radio/Radio.vue
+++ b/src/components/Radio/Radio.vue
@@ -8,7 +8,7 @@
       disabled ? 'disabled' : null,
     ]"
   >
-    <UnnnicIconSvg
+    <UnnnicIcon
       class="unnnic-radio"
       :icon="icon"
       :scheme="color"
@@ -23,6 +23,7 @@
 
 <script setup>
 import { computed } from 'vue';
+import UnnnicIcon from '../Icon.vue';
 
 const props = defineProps({
   modelValue: {

--- a/src/components/SelectSmart/SelectSmartMultipleHeader.vue
+++ b/src/components/SelectSmart/SelectSmartMultipleHeader.vue
@@ -20,7 +20,7 @@
           +{{ selectedOptions.length - multipleSelectedsTags }}
         </p>
       </div>
-      <IconSvg
+      <UnnnicIcon
         class="unnnic-select-smart__options__multiple__selecteds__clear"
         icon="close-1"
         size="xs"
@@ -39,7 +39,7 @@
 
 <script>
 import Tag from '../Tag/Tag.vue';
-import IconSvg from '../Icon.vue';
+import UnnnicIcon from '../Icon.vue';
 import UnnnicI18n from '../../mixins/i18n';
 
 export default {
@@ -47,7 +47,7 @@ export default {
   mixins: [UnnnicI18n],
   components: {
     Tag,
-    IconSvg,
+    UnnnicIcon,
   },
   props: {
     selectedOptions: {

--- a/src/components/Sidebar/SidebarPrimary.vue
+++ b/src/components/Sidebar/SidebarPrimary.vue
@@ -61,7 +61,7 @@
                   }
                 "
               >
-                <IconSvg
+                <UnnnicIcon
                   :icon="option.icon"
                   :scheme="option.active ? 'brand-weni-soft' : 'neutral-cloudy'"
                   :size="!expanded ? 'md' : 'ant'"
@@ -73,7 +73,7 @@
                   :class="option.notify && !expanded ? 'notify' : ''"
                   v-if="option.notify"
                 >
-                  <IconSvg
+                  <UnnnicIcon
                     icon="indicator"
                     scheme="brand-weni-soft"
                     size="ant"
@@ -114,7 +114,7 @@
                 class="option"
                 @click="toggleExpanded"
               >
-                <IconSvg
+                <UnnnicIcon
                   :icon="expanded ? 'close_fullscreen' : 'open_in_full'"
                   :scheme="'neutral-cloudy'"
                   :size="!expanded ? 'md' : 'ant'"
@@ -133,12 +133,12 @@
 <script>
 import ToolTip from '../ToolTip/ToolTip.vue';
 import languageSelect from '../Dropdown/LanguageSelect.vue';
-import iconSvg from '../Icon.vue';
+import UnnnicIcon from '../Icon.vue';
 
 export default {
   components: {
     ToolTip,
-    iconSvg,
+    UnnnicIcon,
     languageSelect,
   },
 

--- a/src/components/Switch/Switch.vue
+++ b/src/components/Switch/Switch.vue
@@ -11,7 +11,7 @@
       {{ textLeft }}
     </div>
 
-    <UnnnicIconSvg
+    <UnnnicIcon
       :class="{ 'unnnic-switch__icon': true, active: isActive }"
       :icon="currentIcon"
       :size="iconSize"
@@ -34,11 +34,11 @@
 </template>
 
 <script>
-import UnnnicIconSvg from '../Icon.vue';
+import UnnnicIcon from '../Icon.vue';
 
 export default {
   name: 'unnnic-switch',
-  components: { UnnnicIconSvg },
+  components: { UnnnicIcon },
   props: {
     size: {
       type: String,

--- a/src/components/Tag/BrandTag.vue
+++ b/src/components/Tag/BrandTag.vue
@@ -7,7 +7,7 @@
     }"
   >
     <span class="unnnic-brand-tag__label">{{ text }}</span>
-    <UnnnicIconSvg
+    <UnnnicIcon
       :icon="disabled ? 'close-1' : 'add-1'"
       :scheme="disabled ? 'neutral-snow' : 'brand-weni-dark'"
       class="unnnic-brand-tag__icon"
@@ -17,12 +17,12 @@
 </template>
 
 <script>
-import UnnnicIconSvg from '../Icon.vue';
+import UnnnicIcon from '../Icon.vue';
 
 export default {
   name: 'unnnic-brand-tag',
   components: {
-    UnnnicIconSvg,
+    UnnnicIcon,
   },
   props: {
     text: {

--- a/src/components/Tag/DefaultTag.vue
+++ b/src/components/Tag/DefaultTag.vue
@@ -10,7 +10,7 @@
       ${disabled ? 'unnnic-tag__label--disabled' : ''}`"
       >{{ text }}</span
     >
-    <UnnnicIconSvg
+    <UnnnicIcon
       v-if="hasCloseIcon"
       icon="close-1"
       class="unnnic-tag__icon"
@@ -22,12 +22,12 @@
 </template>
 
 <script>
-import UnnnicIconSvg from '../Icon.vue';
+import UnnnicIcon from '../Icon.vue';
 
 export default {
   name: 'unnnic-tag',
   components: {
-    UnnnicIconSvg,
+    UnnnicIcon,
   },
   props: {
     text: {

--- a/src/components/Tag/IndicatorTag.vue
+++ b/src/components/Tag/IndicatorTag.vue
@@ -11,7 +11,7 @@
       <span class="unnnic-tag__count">{{ count }}</span>
     </ToolTip>
     <span class="unnnic-tag__label">{{ text }}</span>
-    <UnnnicIconSvg
+    <UnnnicIcon
       v-if="hasBackButton"
       icon="arrow-right-1-1"
       class="unnnic-tag__icon"
@@ -22,13 +22,13 @@
 </template>
 
 <script>
-import UnnnicIconSvg from '../Icon.vue';
+import UnnnicIcon from '../Icon.vue';
 import ToolTip from '../ToolTip/ToolTip.vue';
 
 export default {
   name: 'unnnic-tag',
   components: {
-    UnnnicIconSvg,
+    UnnnicIcon,
     ToolTip,
   },
   props: {

--- a/src/components/UploadArea/UploadArea.vue
+++ b/src/components/UploadArea/UploadArea.vue
@@ -14,7 +14,7 @@
       v-on:drop.stop.prevent="drop"
       @click="() => this.$refs.file.click()"
     >
-      <UnnnicIconSvg
+      <UnnnicIcon
         class="unnnic-upload-area__dropzone__icon"
         icon="upload-bottom-1"
         :scheme="hasError ? 'feedback-red' : 'brand-weni'"
@@ -84,13 +84,13 @@
 <script>
 import mime from 'mime';
 
-import UnnnicIconSvg from '../Icon.vue';
+import UnnnicIcon from '../Icon.vue';
 import UnnnicImportCard from '../ImportCard/ImportCard.vue';
 
 export default {
   name: 'unnnic-upload-area',
   components: {
-    UnnnicIconSvg,
+    UnnnicIcon,
     UnnnicImportCard,
   },
   props: {

--- a/src/stories/Comment.stories.js
+++ b/src/stories/Comment.stories.js
@@ -2,7 +2,7 @@ import unnnicComment from '../components/Comment/Comment.vue';
 import unnnicButton from '../components/Button/Button.vue';
 import unnnicDropdown from '../components/Dropdown/Dropdown.vue';
 import unnnicDropdownItem from '../components/Dropdown/DropdownItem.vue';
-import unnnicIconSvg from '../components/Icon.vue';
+import UnnnicIcon from '../components/Icon.vue';
 
 export default {
   title: 'Example/Comment',
@@ -16,7 +16,7 @@ const Template = (args, { argTypes }) => ({
     unnnicButton,
     unnnicDropdown,
     unnnicDropdownItem,
-    unnnicIconSvg,
+    UnnnicIcon,
   },
   template: `
   <unnnic-comment v-bind="$props">
@@ -24,7 +24,7 @@ const Template = (args, { argTypes }) => ({
     <template v-slot:actions>
     <unnnic-dropdown>
       <template v-slot:trigger>
-        <unnnic-icon-svg
+        <unnnic-icon
           slot="trigger"
           icon="navigation-menu-vertical-1"
           size="sm"


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Some components had the error "Failed to resolve component: UnnnicIcon...", not rendering the necessary icon. The problem was in the way the icon was imported into such components, not following a case pattern (importing as `unnnicIcon` and trying to use it as `UnnnicIcon`, for example).

### Summary of Changes
The import of icons was standardized to `UnnnicIcon`, thus preventing the error from occurring.
