### PR TITLE
[ENGAGE-1109] - Fix TableNext pagination interval (Vue 3)

### DIFF
--- a/src/components/TableNext/TableNext.vue
+++ b/src/components/TableNext/TableNext.vue
@@ -66,7 +66,7 @@
     <TablePagination
       :modelValue="pagination"
       :total="treatedPaginationTotal"
-      :interval="rows.length"
+      :interval="paginationInterval"
       @update:model-value="$emit('update:pagination', $event)"
     />
   </table>
@@ -126,6 +126,10 @@ export default {
       default: 1,
     },
     paginationTotal: {
+      type: Number,
+      default: 1,
+    },
+    paginationInterval: {
       type: Number,
       default: 1,
     },

--- a/src/components/TableNext/TableNext.vue
+++ b/src/components/TableNext/TableNext.vue
@@ -36,7 +36,7 @@
             :target="row.link.target || '_blank'"
           >
             <TableBodyCell
-              v-for="(cell, index) of row.content"
+              v-for="cell of row.content"
               :key="cell + index"
               class="unnnic-table-next__body-cell"
               :cell="cell"
@@ -44,7 +44,7 @@
           </a>
           <template v-else>
             <TableBodyCell
-              v-for="(cell, index) of row.content"
+              v-for="cell of row.content"
               :key="cell + index"
               class="unnnic-table-next__body-cell"
               :cell="cell"
@@ -138,6 +138,8 @@ export default {
       default: false,
     },
   },
+
+  emits: ['update:pagination'],
 
   data() {
     return {

--- a/src/stories/TableNext.stories.js
+++ b/src/stories/TableNext.stories.js
@@ -44,6 +44,7 @@ export default {
       :rows="args.rows || table.rows"
       v-model:pagination="pagination"
       :paginationTotal="125"
+      :paginationInterval="5"
     />
     `,
   }),


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The interval calculated automatically by `rows.length` generated a bug when the request was on the last page and it did not return the `rows.length` of other requests.

### Summary of Changes
Now, a prop with the pagination interval value is expected. Some lint issues were also adjusted.
