### PR TITLE
[ENGAGE-1109] - Fix TableNext pagination interval

### DIFF
--- a/src/components/TableNext/TableNext.vue
+++ b/src/components/TableNext/TableNext.vue
@@ -33,7 +33,7 @@
             :target="row.link.target || '_blank'"
           >
             <TableBodyCell
-              v-for="(cell, index) of row.content"
+              v-for="cell of row.content"
               :key="cell + index"
               class="unnnic-table-next__body-cell"
               :cell="cell"
@@ -41,7 +41,7 @@
           </a>
           <template v-else>
             <TableBodyCell
-              v-for="(cell, index) of row.content"
+              v-for="cell of row.content"
               :key="cell + index"
               class="unnnic-table-next__body-cell"
               :cell="cell"
@@ -61,7 +61,7 @@
       :value="pagination"
       @input="$emit('update:pagination', $event)"
       :total="treatedPaginationTotal"
-      :interval="rows.length"
+      :interval="paginationInterval"
     />
   </table>
 </template>
@@ -120,6 +120,10 @@ export default {
       default: 1,
     },
     paginationTotal: {
+      type: Number,
+      default: 1,
+    },
+    paginationInterval: {
       type: Number,
       default: 1,
     },

--- a/src/stories/TableNext.stories.js
+++ b/src/stories/TableNext.stories.js
@@ -19,6 +19,7 @@ const Template = (args, { argTypes }) => ({
       :rows="$props.rows || table.rows"
       :pagination.sync="pagination"
       :paginationTotal="125"
+      :paginationInterval="5"
     />
   `,
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The interval calculated automatically by `rows.length` generated a bug when the request was on the last page and it did not return the `rows.length` of other requests.

### Summary of Changes
Now, a prop with the pagination interval value is expected. Some lint issues were also adjusted.
