### PR TITLE
[ENGAGE-1260] - Custom size in TableNext headers

### DIFF
--- a/src/components/TableNext/TableNext.vue
+++ b/src/components/TableNext/TableNext.vue
@@ -184,6 +184,9 @@ $tableBorder: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
 
   width: 100%;
 
+  display: flex;
+  flex-direction: column;
+
   &__header {
     &-row {
       @extend %base-row;

--- a/src/components/TableNext/TableNext.vue
+++ b/src/components/TableNext/TableNext.vue
@@ -1,7 +1,10 @@
 <template>
   <table class="unnnic-table-next">
     <thead class="unnnic-table-next__header">
-      <tr class="unnnic-table-next__header-row">
+      <tr
+        class="unnnic-table-next__header-row"
+        :style="{ gridTemplateColumns }"
+      >
         <th
           v-for="(cell, index) of headers"
           :key="cell.content + index"
@@ -28,10 +31,14 @@
           v-for="(row, index) of rows"
           :key="row.content + index"
           class="unnnic-table-next__body-row"
+          :style="{
+            gridTemplateColumns: row.link ? 'auto' : gridTemplateColumns,
+          }"
         >
           <a
             v-if="row.link"
             class="unnnic-table-next__body-row--redirect"
+            :style="{ gridTemplateColumns }"
             :href="row.link.url"
             :target="row.link.target || '_blank'"
           >
@@ -92,6 +99,7 @@ export default {
     /**
      * @typedef {Array} HeaderItem
      * @property {string} content - The content of the header cell.
+     * @property {number} size - The size of the header cell in fractions.
      * @property {boolean|undefined} isSortable - Indicates if the cell is enabled for sorting.
      */
 
@@ -156,6 +164,9 @@ export default {
   computed: {
     treatedPaginationTotal() {
       return this.rows.length === 0 ? 0 : this.paginationTotal;
+    },
+    gridTemplateColumns() {
+      return this.headers.map((header) => `${header.size || 1}fr`).join(' ');
     },
   },
 };
@@ -268,7 +279,6 @@ $tableBorder: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
 
   %base-row {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
     align-items: center;
   }
 }

--- a/src/components/TableNext/validation.js
+++ b/src/components/TableNext/validation.js
@@ -1,11 +1,19 @@
-const validateHeader = (cell) => {
-  const isContentString = typeof cell.content !== 'string';
+const validateHeader = (header) => {
+  const isContentString = typeof header.content !== 'string';
   if (isContentString) {
     throw new Error('Each item in "headers" must have "content" as a string.');
   }
 
+  const isSizePositiveNumber =
+    'size' in header && (typeof header.size !== 'number' || header.size < 0);
+  if (isSizePositiveNumber) {
+    throw new Error(
+      'Each item in "headers" that contains "size" must assign it as positive number',
+    );
+  }
+
   const isSortableBoolean =
-    'isSortable' in cell && typeof cell.isSortable !== 'boolean';
+    'isSortable' in header && typeof header.isSortable !== 'boolean';
   if (isSortableBoolean) {
     throw new Error(
       'Each item in "headers" that contains “isSortable” must assign it as boolean',

--- a/src/stories/TableNext.stories.js
+++ b/src/stories/TableNext.stories.js
@@ -19,6 +19,7 @@ export default {
           headers: [
             {
               content: 'ID',
+              size: 0.3,
             },
             {
               content: 'Name',


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
A variation to set the size for each column was necessary for the table on some occasions, as in the demonstration.

### Summary of Changes
- Added the possibility of passing the size for each header;
- Added a size of 0.3 to the ID header of stories;
- Added validation to receive only positive numbers if the header has the "size" field.

### Demonstration <!--- (If not appropriate, remove this topic) -->
Demonstration where the ID header has a size of just 0.3fr of the grid:
![image](https://github.com/user-attachments/assets/cb147e5b-e5a6-413f-874f-51ac9991c72b)
