### PR TITLE
[ENGAGE-1353] - Drawer without overlay and dynamic icon

### DIFF
--- a/src/components/Drawer/Drawer.vue
+++ b/src/components/Drawer/Drawer.vue
@@ -31,7 +31,7 @@
           </section>
           <UnnnicIcon
             class="unnnic-drawer__close"
-            icon="arrow_back"
+            :icon="closeIcon"
             size="avatar-nano"
             clickable
             @click="close"
@@ -85,6 +85,7 @@ export default {
     },
     description: {
       type: String,
+      default: '',
     },
     disabledPrimaryButton: {
       type: Boolean,
@@ -104,6 +105,7 @@ export default {
     },
     primaryButtonText: {
       type: String,
+      default: '',
     },
     primaryButtonType: {
       type: String,
@@ -111,6 +113,7 @@ export default {
     },
     secondaryButtonText: {
       type: String,
+      default: '',
     },
     wide: {
       type: Boolean,
@@ -123,6 +126,10 @@ export default {
     withoutOverlay: {
       type: Boolean,
       default: false,
+    },
+    closeIcon: {
+      type: String,
+      default: 'arrow_back',
     },
   },
   emits: ['primaryButtonClick', 'secondaryButtonClick', 'close'],

--- a/src/components/Drawer/Drawer.vue
+++ b/src/components/Drawer/Drawer.vue
@@ -69,14 +69,14 @@
 </template>
 
 <script>
-import unnnicIcon from '../Icon.vue';
-import unnnicButton from '../Button/Button.vue';
+import UnnnicIcon from '../Icon.vue';
+import UnnnicButton from '../Button/Button.vue';
 
 export default {
   name: 'UnnnicDrawer',
   components: {
-    unnnicIcon,
-    unnnicButton,
+    UnnnicIcon,
+    UnnnicButton,
   },
   props: {
     title: {

--- a/src/components/Drawer/Drawer.vue
+++ b/src/components/Drawer/Drawer.vue
@@ -4,6 +4,7 @@
     class="unnnic-drawer"
   >
     <section
+      v-if="!withoutOverlay"
       class="unnnic-drawer__overlay"
       @click.stop="close"
     />
@@ -118,6 +119,10 @@ export default {
     modelValue: {
       type: Boolean,
       required: true,
+    },
+    withoutOverlay: {
+      type: Boolean,
+      default: false,
     },
   },
   emits: ['primaryButtonClick', 'secondaryButtonClick', 'close'],

--- a/src/stories/Drawer.stories.js
+++ b/src/stories/Drawer.stories.js
@@ -28,6 +28,7 @@ export default {
     secondaryButtonText: { control: { type: 'text' } },
     modelValue: { control: { type: 'boolean' } },
     wide: { control: { type: 'boolean' } },
+    withoutOverlay: { control: { type: 'boolean' } },
   },
   render: (args) => ({
     setup() {
@@ -152,5 +153,23 @@ export const ContentVideo = {
     title: 'Title',
     description: 'Description',
     wide: true,
+  },
+};
+
+export const WithoutOverlay = {
+  parameters: {
+    docs: {
+      description: {
+        story: `It is recommended to use this variation for contexts where the drawer occupies 
+        the screen with another drawer or modal (components with overlay in general).`,
+      },
+    },
+  },
+  args: {
+    title: 'Title',
+    description: 'Description',
+    primaryButtonText: 'Confirmar',
+    secondaryButtonText: 'Cancelar',
+    withoutOverlay: true,
   },
 };


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
In some contexts, the drawer is used together with a modal. Therefore, to avoid having two overlays on the screen, the Drawer variation without the overlay was required. Also, in other contexts it makes more sense for the Drawer close icon to be something other than an arrow.

### Summary of Changes
- Added Drawer without overlay variation and its story;
- Fixed close icon of Drawer to be dynamic.
