### PR TITLE
[ENGAGE-1245] - Fix pre-release workflow

### DIFF
--- a/.github/workflows/npm-publish-pre-release.yaml
+++ b/.github/workflows/npm-publish-pre-release.yaml
@@ -27,6 +27,7 @@ jobs:
           git config --global user.name "GitHub Actions Bot"
       - name: Create Pre Release Version
         run: |
+          git fetch --tags
           yarn version --prerelease --preid alpha
           git push origin HEAD:staging-vue3
           git push --tags

--- a/.github/workflows/npm-publish-pre-release.yaml
+++ b/.github/workflows/npm-publish-pre-release.yaml
@@ -27,10 +27,10 @@ jobs:
           git config --global user.name "GitHub Actions Bot"
       - name: Create Pre Release Version
         run: |
-          git fetch --tags
           yarn version --prerelease --preid alpha
+          NEW_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
           git push origin HEAD:staging-vue3
-          git push --tags
+          git push origin $NEW_TAG
       - name: Publish Package
         run: yarn publish
         env:


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The pre-release version was not being created by the workflow due to a conflict in the push on existing tags.

### Summary of Changes
Change in the workflow that creates the pre release to upload only the tag created in the `yarn version`.
