### PR TITLE
[ENGAGE-1513] - Drawer distinct close and back actions

### DIFF
--- a/src/components/Drawer/Drawer.vue
+++ b/src/components/Drawer/Drawer.vue
@@ -34,7 +34,7 @@
             :icon="closeIcon"
             size="avatar-nano"
             clickable
-            @click="close"
+            @click="back"
           />
         </header>
         <section class="unnnic-drawer__content">
@@ -131,8 +131,12 @@ export default {
       type: String,
       default: 'arrow_back',
     },
+    distinctCloseBack: {
+      type: Boolean,
+      default: false,
+    },
   },
-  emits: ['primaryButtonClick', 'secondaryButtonClick', 'close'],
+  emits: ['primaryButtonClick', 'secondaryButtonClick', 'close', 'back'],
   data() {
     return {
       showDrawer: true,
@@ -144,12 +148,22 @@ export default {
     },
   },
   methods: {
-    close() {
+    transitionClose(callback) {
       this.showDrawer = false;
       setTimeout(() => {
-        this.$emit('close');
+        callback?.();
         this.showDrawer = true;
       }, 200);
+    },
+    close() {
+      this.transitionClose(() => this.$emit('close'));
+    },
+    back() {
+      if (this.distinctCloseBack) {
+        this.transitionClose(() => this.$emit('back'));
+      } else {
+        this.close();
+      }
     },
   },
 };

--- a/src/stories/Drawer.stories.js
+++ b/src/stories/Drawer.stories.js
@@ -1,3 +1,5 @@
+import { action } from '@storybook/addon-actions';
+
 import UnnnicDrawer from '../components/Drawer/Drawer.vue';
 import UnnnicButton from '../components/Button/Button.vue';
 
@@ -41,18 +43,24 @@ export default {
       };
     },
     methods: {
-      primaryClick() {
-        console.log('primaryClick');
+      primaryClick: action('primaryButtonClick'),
+      secondaryClick: action('secondaryButtonClick'),
+      closeAction: action('close'),
+      backAction: action('back'),
+      close() {
+        this.closeAction();
+        this.opened = false;
       },
-      secondaryClick() {
-        console.log('secondaryClick');
+      back() {
+        this.backAction();
+        this.opened = false;
       },
     },
     template: `
       <div>
         <pre>v-model: {{ opened }}</pre>
         <button @click="opened = !opened">Change</button>
-        <unnnic-drawer v-bind="args" v-model="opened" @close="opened = false" @primaryButtonClick="primaryClick" @secondaryButtonClick="secondaryClick">
+        <unnnic-drawer v-bind="args" v-model="opened" @close="close" @back="back" @primaryButtonClick="primaryClick" @secondaryButtonClick="secondaryClick">
           <template #content>
             <p style="padding: 0; margin:0;">Conteúdo</p>
           </template>
@@ -68,6 +76,7 @@ export const Default = {
     description: 'Description',
     primaryButtonText: 'Confirmar',
     secondaryButtonText: 'Cancelar',
+    distinctCloseBack: true,
   },
 };
 
@@ -93,12 +102,8 @@ export const ContentOverflowed = {
       };
     },
     methods: {
-      primaryClick() {
-        console.log('primaryClick');
-      },
-      secondaryClick() {
-        console.log('secondaryClick');
-      },
+      primaryClick: action('primaryButtonClick'),
+      secondaryClick: action('secondaryButtonClick'),
     },
     template: `
       <div>


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [x] Other

### Motivation and Context
Some contexts require the separation of the functionalities given to the back button and close the drawer.

### Summary of Changes
The option to separate the "back" and "close" events has been added. Also, the logic for the drawer close transition has been separated in case the context needs more than the event emission after the transition.

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->

https://github.com/user-attachments/assets/a50af34d-eeeb-4bfc-bf3b-a0a7c5dd9490

