### PR TITLE
[ENGAGE-1469] - Add drawer xl variation

### DIFF
--- a/src/components/Drawer/Drawer.vue
+++ b/src/components/Drawer/Drawer.vue
@@ -16,7 +16,7 @@
         v-if="showDrawer"
         :class="[
           'unnnic-drawer__container',
-          wide && 'unnnic-drawer__container--wide',
+          `unnnic-drawer__container--${size}`,
         ]"
       >
         <header class="unnnic-drawer__header">
@@ -114,6 +114,13 @@ export default {
     secondaryButtonText: {
       type: String,
       default: '',
+    },
+    size: {
+      type: String,
+      default: 'md',
+      validator(val) {
+        return ['md', 'lg', 'xl'].includes(val);
+      },
     },
     wide: {
       type: Boolean,
@@ -233,10 +240,17 @@ export default {
   justify-content: space-between;
   height: 100%;
   background-color: $unnnic-color-neutral-white;
-  width: calc(100% / 3);
 
-  &--wide {
+  &--md {
+    width: calc(100% / 3);
+  }
+
+  &--lg {
     width: 50%;
+  }
+
+  &--xl {
+    width: 75%;
   }
 
   .unnnic-drawer__header {

--- a/src/stories/Drawer.stories.js
+++ b/src/stories/Drawer.stories.js
@@ -29,7 +29,10 @@ export default {
     primaryButtonText: { control: { type: 'text' } },
     secondaryButtonText: { control: { type: 'text' } },
     modelValue: { control: { type: 'boolean' } },
-    wide: { control: { type: 'boolean' } },
+    size: {
+      options: ['md', 'lg', 'xl'],
+      control: { type: 'select' },
+    },
     withoutOverlay: { control: { type: 'boolean' } },
   },
   render: (args) => ({
@@ -80,13 +83,23 @@ export const Default = {
   },
 };
 
-export const Wide = {
+export const Large = {
   args: {
     title: 'Title',
     description: 'Description',
     primaryButtonText: 'Confirmar',
     secondaryButtonText: 'Cancelar',
-    wide: true,
+    size: 'lg',
+  },
+};
+
+export const ExtraLarge = {
+  args: {
+    title: 'Title',
+    description: 'Description',
+    primaryButtonText: 'Confirmar',
+    secondaryButtonText: 'Cancelar',
+    size: 'xl',
   },
 };
 
@@ -127,7 +140,7 @@ export const ContentOverflowed = {
     description: 'Description',
     primaryButtonText: 'Confirmar',
     secondaryButtonText: 'Cancelar',
-    wide: true,
+    size: 'lg',
   },
 };
 
@@ -157,7 +170,7 @@ export const ContentVideo = {
   args: {
     title: 'Title',
     description: 'Description',
-    wide: true,
+    size: 'lg',
   },
 };
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Due to the need for a drawer that takes up more space on the screen, the xl variation was implemented, which takes up 75% of the space

### Summary of Changes
<!--- Describe your changes in detail -->
- Change `wide` pro to `size`
- Add xl variation (width 75%)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->
![image](https://github.com/user-attachments/assets/5e508887-687a-44f4-a5ee-72c783abca2f)

