### PR TITLE
[ENGAGE-1514] Fix auto open first child prop (v3)

### DIFF
--- a/src/components/Sidebar/SidebarItem.vue
+++ b/src/components/Sidebar/SidebarItem.vue
@@ -77,7 +77,7 @@ const props = defineProps({
     type: Object,
     default: () => ({ item: false, childIndex: null }),
   },
-  autoNavigateSingleChild: {
+  autoNavigateFirstChild: {
     type: Boolean,
     default: false
   }
@@ -100,8 +100,8 @@ const handleShowChildrenList = () => {
   showChildrenList.value = !showChildrenList.value;
   
   const isOpening = showChildrenList.value
-  if (isOpening && props.item.children?.length === 1 && props.autoNavigateSingleChild) {
-    emit('navigate', { item: props.item, child: 0 });
+  if (isOpening  && props.autoNavigateFirstChild) {
+    emit('navigate', { item: props.item, child: props.item.children[0] });
   }
 };
 

--- a/src/components/Sidebar/index.vue
+++ b/src/components/Sidebar/index.vue
@@ -16,7 +16,7 @@
             childIndex: active.childIndex,
           }"
           @navigate="handleNavigate($event)"
-          :autoNavigateSingleChild="autoNavigateSingleChild"
+          :autoNavigateFirstChild="autoNavigateFirstChild"
         />
       </li>
     </ul>
@@ -63,7 +63,7 @@ const props = defineProps({
     type: Object,
     default: () => ({ itemIndex: null, childIndex: null }),
   },
-  autoNavigateSingleChild: {
+  autoNavigateFirstChild: {
     type: Boolean,
     default: false
   }

--- a/src/stories/Sidebar.stories.js
+++ b/src/stories/Sidebar.stories.js
@@ -94,7 +94,7 @@ export const Default = {
     items: items,
     width: '200px',
     active: { itemIndex: 1, childIndex: 0 },
-    autoNavigateSingleChild: true,
+    autoNavigateFirstChild: true,
   },
 };
 
@@ -103,7 +103,7 @@ export const Overflowed = {
     items: Array.from({length: 50}).map((_item, index) => ({ label: `Item ${index}`, icon: 'tune' })),
     width: '200px',
     active: { itemIndex: 1, childIndex: 0 },
-    autoNavigateSingleChild: true,
+    autoNavigateFirstChild: true,
   },
 };
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When the flag `autoNavigateFirstChild` is activated , the first item of the children must be opened regardless of its quantity

### Summary of Changes
<!--- Describe your changes in detail -->
- Fix autoNavigateFirstChild handler