### PR TITLE
[NEXUS-2170] - Left and Right icons at Tag component

### DIFF
--- a/src/components/Tag/BrandTag.vue
+++ b/src/components/Tag/BrandTag.vue
@@ -37,10 +37,6 @@ export default {
       type: Boolean,
       default: false,
     },
-    icon: {
-      type: String,
-      default: null,
-    },
   },
   methods: {
     closeClicked() {

--- a/src/components/Tag/DefaultTag.vue
+++ b/src/components/Tag/DefaultTag.vue
@@ -22,7 +22,7 @@
     <section
       v-if="rightIcon || hasCloseIcon"
       :class="{ 'unnnic-tag__icon': true, clickable: !rightIcon }"
-      @click.stop="hasCloseIcon ? emitClose : () => {}"
+      @click.stop="hasCloseIcon ? emitClose() : () => {}"
     >
       <UnnnicIcon
         :icon="rightIcon || 'close'"
@@ -101,6 +101,7 @@ export default {
   align-items: center;
   justify-content: center;
   border-radius: $unnnic-border-radius-pill;
+  padding: 0 $unnnic-spacing-xs;
 
   &--disabled {
     background-color: $unnnic-color-background-sky;

--- a/src/components/Tag/DefaultTag.vue
+++ b/src/components/Tag/DefaultTag.vue
@@ -1,27 +1,36 @@
 <template>
-  <div
+  <section
     :class="`unnnic-tag
         ${!disabled ? `unnnic-tag-scheme--${scheme}` : `unnnic-tag--disabled`}
         ${clickable ? 'unnnic-tag--clickable' : ''}`"
   >
+    <section
+      v-if="leftIcon"
+      class="unnnic-tag__icon"
+    >
+      <UnnnicIcon
+        :icon="leftIcon"
+        :scheme="scheme"
+        size="sm"
+      />
+    </section>
     <span
       :class="`unnnic-tag__label
-      ${hasCloseIcon ? 'unnnic-tag__label--hasIcon' : ''}
       ${disabled ? 'unnnic-tag__label--disabled' : ''}`"
       >{{ text }}</span
     >
-    <div
-      v-if="hasCloseIcon"
-      class="unnnic-tag__icon"
-      @click.stop="emitClose"
+    <section
+      v-if="rightIcon || hasCloseIcon"
+      :class="{ 'unnnic-tag__icon': true, clickable: !rightIcon }"
+      @click.stop="hasCloseIcon ? emitClose : () => {}"
     >
       <UnnnicIcon
-        icon="close-1"
-        scheme="neutral-darkest"
-        size="xs"
+        :icon="rightIcon || 'close'"
+        :scheme="rightIcon ? scheme : 'neutral-darkest'"
+        size="sm"
       />
-    </div>
-  </div>
+    </section>
+  </section>
 </template>
 
 <script>
@@ -52,6 +61,14 @@ export default {
     scheme: {
       type: String,
       default: 'aux-purple',
+    },
+    leftIcon: {
+      type: String,
+      default: null,
+    },
+    rightIcon: {
+      type: String,
+      default: null,
     },
   },
   methods: {
@@ -107,22 +124,19 @@ export default {
     font-size: $unnnic-font-size-body-md;
     font-weight: $unnnic-font-weight-regular;
     line-height: ($unnnic-font-size-body-md + $unnnic-line-height-medium);
-    padding: $unnnic-spacing-stack-nano $unnnic-inline-ant;
+    padding: $unnnic-spacing-stack-nano;
     color: $unnnic-color-neutral-darkest;
 
     &--disabled {
       color: $unnnic-color-neutral-cloudy;
     }
-
-    &--hasIcon {
-      padding-left: $unnnic-inline-ant;
-      padding-right: $unnnic-spacing-stack-nano;
-    }
   }
 
   &__icon {
     display: flex;
-    margin-right: $unnnic-inline-ant;
+  }
+
+  .clickable {
     cursor: pointer;
   }
 }

--- a/src/components/Tag/Tag.vue
+++ b/src/components/Tag/Tag.vue
@@ -12,7 +12,8 @@
     :clickable="clickable"
     :tooltipText="tooltipText"
     :enableTooltip="enableTooltip"
-    :icon="icon"
+    :leftIcon="leftIcon"
+    :rightIcon="rightIcon"
   />
 </template>
 
@@ -67,9 +68,13 @@ export default {
       type: Boolean,
       default: false,
     },
-    icon: {
+    leftIcon: {
       type: String,
-      default: null,
+      default: '',
+    },
+    rightIcon: {
+      type: String,
+      default: '',
     },
   },
   computed: {

--- a/src/stories/Tag.stories.js
+++ b/src/stories/Tag.stories.js
@@ -1,9 +1,10 @@
-import unnnicTag from '../components/Tag/Tag.vue';
+import UnnnicTag from '../components/Tag/Tag.vue';
 import colorsList from '../utils/colorsList';
 
 export default {
-  title: 'Example/Tag',
-  component: unnnicTag,
+  title: 'Data Display/Tag',
+  component: UnnnicTag,
+  tags: ['autodocs'],
   argTypes: {
     text: { control: { type: 'text' } },
     type: {
@@ -22,6 +23,30 @@ export const Default = {
   args: {
     text: 'Label',
     type: 'default',
+  },
+};
+
+export const LeftIcon = {
+  args: {
+    text: 'Label',
+    type: 'default',
+    leftIcon: 'check_circle',
+  },
+};
+
+export const RightIcon = {
+  args: {
+    text: 'Label',
+    type: 'default',
+    rightIcon: 'check_circle',
+  },
+};
+
+export const CloseIcon = {
+  args: {
+    text: 'Label',
+    type: 'default',
+    hasCloseIcon: true,
   },
 };
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Add icon variation in Tag component.

### Summary of Changes
- Added leftIcon and rightIcon props to the Tag component;
- Added documentation for these new variations.
