### PR TITLE
[NEXUS-2170] - TableNext variations

### DIFF
--- a/src/components/TableNext/TableNext.vue
+++ b/src/components/TableNext/TableNext.vue
@@ -1,7 +1,7 @@
 <template>
   <table class="unnnic-table-next">
     <thead
-      v-if="!hideHeaders"
+      v-if="!shouldHideHeaders"
       class="unnnic-table-next__header"
       data-testid="header"
     >
@@ -24,7 +24,7 @@
     <tbody
       :class="{
         'unnnic-table-next__body': true,
-        'unnnic-table-next__body--hide-headers': hideHeaders,
+        'unnnic-table-next__body--hide-headers': shouldHideHeaders,
       }"
       data-testid="body"
     >
@@ -141,7 +141,7 @@ export default {
      */
     headers: {
       type: Array,
-      required: true,
+      default: () => [],
       validator: validateHeaders,
     },
 
@@ -157,7 +157,7 @@ export default {
      */
     rows: {
       type: Array,
-      required: true,
+      default: () => [],
       validator: validateRows,
     },
 
@@ -209,7 +209,12 @@ export default {
       return this.rows.length === 0 ? 0 : this.paginationTotal;
     },
     gridTemplateColumns() {
-      return this.headers.map((header) => `${header.size || 1}fr`).join(' ');
+      return this.headers.length
+        ? this.headers.map((header) => `${header.size || 1}fr`).join(' ')
+        : this.rows[0].content.map(() => `1fr`).join(' ');
+    },
+    shouldHideHeaders() {
+      return this.hideHeaders || !this.headers.length;
     },
   },
 };

--- a/src/components/TableNext/TableNext.vue
+++ b/src/components/TableNext/TableNext.vue
@@ -131,7 +131,7 @@ export default {
     /**
      * @typedef {Array} HeaderItem
      * @property {string} content - The content of the header cell.
-     * @property {number} size - The size of the header cell in fractions.
+     * @property {number|string} size - The size of the header cell, either as a fraction (number) or 'auto'.
      * @property {boolean|undefined} isSortable - Indicates if the cell is enabled for sorting.
      */
 
@@ -209,9 +209,17 @@ export default {
       return this.rows.length === 0 ? 0 : this.paginationTotal;
     },
     gridTemplateColumns() {
-      return this.headers.length
-        ? this.headers.map((header) => `${header.size || 1}fr`).join(' ')
-        : this.rows[0].content.map(() => `1fr`).join(' ');
+      const defaultSize = '1fr';
+      const getHeaderColumnSize = (header) =>
+        typeof header.size === 'number'
+          ? `${header.size || 1}fr`
+          : header.size || defaultSize;
+
+      const columnSizes = this.headers.length
+        ? this.headers.map(getHeaderColumnSize)
+        : this.rows[0].content.map(() => defaultSize);
+
+      return columnSizes.join(' ');
     },
     shouldHideHeaders() {
       return this.hideHeaders || !this.headers.length;

--- a/src/components/TableNext/TableNext.vue
+++ b/src/components/TableNext/TableNext.vue
@@ -50,7 +50,10 @@
             <TableBodyCell
               v-for="cell of row.content"
               :key="cell + index"
-              class="unnnic-table-next__body-cell"
+              :class="[
+                'unnnic-table-next__body-cell',
+                `unnnic-table-next__body-cell--${size}`,
+              ]"
               data-testid="body-cell"
               :cell="cell"
             />
@@ -59,7 +62,10 @@
             <TableBodyCell
               v-for="cell of row.content"
               :key="cell + index"
-              class="unnnic-table-next__body-cell"
+              :class="[
+                'unnnic-table-next__body-cell',
+                `unnnic-table-next__body-cell--${size}`,
+              ]"
               data-testid="body-cell"
               :cell="cell"
             />
@@ -70,8 +76,17 @@
         v-else
         class="unnnic-table-next__body-row"
       >
-        <td class="unnnic-table-next__body-cell" data-testid="body-cell">
-          <p class="unnnic-table-next__body-cell-text" data-testid="body-cell-text">
+        <td
+          :class="[
+            'unnnic-table-next__body-cell',
+            `unnnic-table-next__body-cell--${size}`,
+          ]"
+          data-testid="body-cell"
+        >
+          <p
+            class="unnnic-table-next__body-cell-text"
+            data-testid="body-cell-text"
+          >
             {{ i18n('without_results') }}
           </p>
         </td>
@@ -134,6 +149,12 @@ export default {
       type: Array,
       required: true,
       validator: validateRows,
+    },
+
+    size: {
+      type: String,
+      default: 'sm',
+      validator: (value) => ['md', 'sm'].includes(value),
     },
 
     pagination: {
@@ -261,6 +282,11 @@ $tableBorder: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
         text-overflow: ellipsis;
       }
     }
+
+    td.unnnic-table-next__body-cell--sm {
+      padding: $unnnic-spacing-ant $unnnic-spacing-sm;
+    }
+
     &-cell--loading {
       margin: $unnnic-spacing-xl 0;
       padding: 0;
@@ -274,7 +300,7 @@ $tableBorder: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
   %base-cell {
     border-collapse: collapse;
 
-    padding: $unnnic-spacing-ant $unnnic-spacing-sm;
+    padding: $unnnic-spacing-sm $unnnic-spacing-sm;
 
     font-family: $unnnic-font-family-secondary;
     font-size: $unnnic-font-size-body-gt;

--- a/src/components/TableNext/TableNext.vue
+++ b/src/components/TableNext/TableNext.vue
@@ -1,6 +1,10 @@
 <template>
   <table class="unnnic-table-next">
-    <thead class="unnnic-table-next__header">
+    <thead
+      v-if="!hideHeaders"
+      class="unnnic-table-next__header"
+      data-testid="header"
+    >
       <tr
         class="unnnic-table-next__header-row"
         data-testid="header-row"
@@ -17,7 +21,13 @@
       </tr>
     </thead>
 
-    <tbody class="unnnic-table-next__body">
+    <tbody
+      :class="{
+        'unnnic-table-next__body': true,
+        'unnnic-table-next__body--hide-headers': hideHeaders,
+      }"
+      data-testid="body"
+    >
       <tr
         v-if="isLoading"
         class="unnnic-table-next__body-row"
@@ -157,6 +167,11 @@ export default {
       validator: (value) => ['md', 'sm'].includes(value),
     },
 
+    hideHeaders: {
+      type: Boolean,
+      default: false,
+    },
+
     pagination: {
       type: Number,
       default: 1,
@@ -246,8 +261,17 @@ $tableBorder: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
   }
 
   &__body {
+    &--hide-headers {
+      .unnnic-table-next__body-row:first-of-type {
+        border-radius: $unnnic-border-radius-sm $unnnic-border-radius-sm 0 0;
+        border-top: $tableBorder;
+      }
+    }
+
     &-row {
       @extend %base-row;
+
+      overflow: hidden;
 
       border: $tableBorder;
       border-collapse: collapse;

--- a/src/components/TableNext/__test__/TableNext.spec.js
+++ b/src/components/TableNext/__test__/TableNext.spec.js
@@ -45,6 +45,16 @@ describe('TableNext.vue', () => {
       // The first column uses the default size of 1fr,
       // and the second column is set to 2fr as specified in the header configuration.
     });
+
+    it('do not render the header if it has the hideHeaders prop', async () => {
+      await wrapper.setProps({ headers, hideHeaders: true });
+
+      const header = wrapper.find('[data-testid="header"]');
+      expect(header.exists()).toBe(false);
+
+      const body = wrapper.find('[data-testid="body"]');
+      expect(body.classes()).toContain('unnnic-table-next__body--hide-headers');
+    });
   });
 
   describe('Row rendering and behaviors', () => {

--- a/src/components/TableNext/__test__/TableNext.spec.js
+++ b/src/components/TableNext/__test__/TableNext.spec.js
@@ -46,6 +46,17 @@ describe('TableNext.vue', () => {
       // and the second column is set to 2fr as specified in the header configuration.
     });
 
+    it('renders rows with default 1fr when no headers are provided', async () => {
+      wrapper = mount(TableNext, {
+        props: { rows },
+      });
+
+      const rowElement = wrapper.find('[data-testid="body-row"]');
+      const gridTemplateColumns = rowElement.attributes('style');
+      expect(gridTemplateColumns).toContain('1fr 1fr');
+      // Since headers are absent, each row column should default to 1fr as per the logic in `gridTemplateColumns`.
+    });
+
     it('do not render the header if it has the hideHeaders prop', async () => {
       await wrapper.setProps({ headers, hideHeaders: true });
 
@@ -87,8 +98,10 @@ describe('TableNext.vue', () => {
       expect(secondLink.attributes('target')).toBe('_self');
     });
 
-    it('renders "no matching results" message when there are no rows', async () => {
-      await wrapper.setProps({ headers, rows: [] });
+    it('renders "no matching results" message when there are no rows', () => {
+      wrapper = mount(TableNext, {
+        props: { headers },
+      });
 
       const noResultsMessage = wrapper.find('[data-testid="body-cell-text"]');
       expect(noResultsMessage.text()).toBe('No matching results');

--- a/src/components/TableNext/__test__/TableNext.spec.js
+++ b/src/components/TableNext/__test__/TableNext.spec.js
@@ -66,6 +66,26 @@ describe('TableNext.vue', () => {
       const body = wrapper.find('[data-testid="body"]');
       expect(body.classes()).toContain('unnnic-table-next__body--hide-headers');
     });
+
+    it('renders headers with mixed sizes (number and string)', () => {
+      wrapper = mount(TableNext, {
+        props: {
+          headers: [
+            { content: 'ID', size: 1 },
+            { content: 'Name', size: 'auto' },
+            { content: 'Age', size: 2 },
+          ],
+          rows,
+        },
+      });
+
+      const headerRow = wrapper.find('[data-testid="header-row"]');
+      const gridTemplateColumns = headerRow.attributes('style');
+
+      expect(gridTemplateColumns).toContain(
+        'grid-template-columns: 1fr auto 2fr',
+      );
+    });
   });
 
   describe('Row rendering and behaviors', () => {

--- a/src/components/TableNext/__test__/__snapshots__/TableNext.spec.js.snap
+++ b/src/components/TableNext/__test__/__snapshots__/TableNext.spec.js.snap
@@ -2,34 +2,34 @@
 
 exports[`TableNext.vue > matches the snapshot 1`] = `
 "<table data-v-2143c794="" class="unnnic-table-next">
-  <thead data-v-2143c794="" class="unnnic-table-next__header">
+  <thead data-v-2143c794="" class="unnnic-table-next__header" data-testid="header">
     <tr data-v-2143c794="" class="unnnic-table-next__header-row" data-testid="header-row" style="grid-template-columns: 1fr 2fr;">
       <th data-v-2143c794="" class="unnnic-table-next__header-cell" data-testid="header-cell">Header 1</th>
       <th data-v-2143c794="" class="unnnic-table-next__header-cell" data-testid="header-cell">Header 2</th>
     </tr>
   </thead>
-  <tbody data-v-2143c794="" class="unnnic-table-next__body">
+  <tbody data-v-2143c794="" class="unnnic-table-next__body" data-testid="body">
     <tr data-v-2143c794="" class="unnnic-table-next__body-row" data-testid="body-row" style="grid-template-columns: 1fr 2fr;">
-      <td data-v-fd58013b="" data-v-2143c794="" class="unnnic-table-next__body-cell" data-testid="body-cell">
+      <td data-v-fd58013b="" data-v-2143c794="" class="unnnic-table-next__body-cell unnnic-table-next__body-cell unnnic-table-next__body-cell--sm" data-testid="body-cell">
         <p data-v-fd58013b="" class="unnnic-table-next__body-cell-text" data-testid="body-cell-text">Row 1 Col 1</p>
       </td>
-      <td data-v-fd58013b="" data-v-2143c794="" class="unnnic-table-next__body-cell" data-testid="body-cell">
+      <td data-v-fd58013b="" data-v-2143c794="" class="unnnic-table-next__body-cell unnnic-table-next__body-cell unnnic-table-next__body-cell--sm" data-testid="body-cell">
         <p data-v-fd58013b="" class="unnnic-table-next__body-cell-text" data-testid="body-cell-text">Row 1 Col 2</p>
       </td>
     </tr>
     <tr data-v-2143c794="" class="unnnic-table-next__body-row" data-testid="body-row" style="grid-template-columns: auto;"><a data-v-2143c794="" class="unnnic-table-next__body-row--redirect" data-testid="body-row-redirect" style="grid-template-columns: 1fr 2fr;" href="#" target="_blank">
-        <td data-v-fd58013b="" data-v-2143c794="" class="unnnic-table-next__body-cell" data-testid="body-cell">
+        <td data-v-fd58013b="" data-v-2143c794="" class="unnnic-table-next__body-cell unnnic-table-next__body-cell unnnic-table-next__body-cell--sm" data-testid="body-cell">
           <p data-v-fd58013b="" class="unnnic-table-next__body-cell-text" data-testid="body-cell-text">Row 2 Col 1</p>
         </td>
-        <td data-v-fd58013b="" data-v-2143c794="" class="unnnic-table-next__body-cell" data-testid="body-cell">
+        <td data-v-fd58013b="" data-v-2143c794="" class="unnnic-table-next__body-cell unnnic-table-next__body-cell unnnic-table-next__body-cell--sm" data-testid="body-cell">
           <p data-v-fd58013b="" class="unnnic-table-next__body-cell-text" data-testid="body-cell-text">Row 2 Col 2</p>
         </td>
       </a></tr>
     <tr data-v-2143c794="" class="unnnic-table-next__body-row" data-testid="body-row" style="grid-template-columns: auto;"><a data-v-2143c794="" class="unnnic-table-next__body-row--redirect" data-testid="body-row-redirect" style="grid-template-columns: 1fr 2fr;" href="#" target="_self">
-        <td data-v-fd58013b="" data-v-2143c794="" class="unnnic-table-next__body-cell" data-testid="body-cell">
+        <td data-v-fd58013b="" data-v-2143c794="" class="unnnic-table-next__body-cell unnnic-table-next__body-cell unnnic-table-next__body-cell--sm" data-testid="body-cell">
           <p data-v-fd58013b="" class="unnnic-table-next__body-cell-text" data-testid="body-cell-text">Row 3 Col 1</p>
         </td>
-        <td data-v-fd58013b="" data-v-2143c794="" class="unnnic-table-next__body-cell" data-testid="body-cell">
+        <td data-v-fd58013b="" data-v-2143c794="" class="unnnic-table-next__body-cell unnnic-table-next__body-cell unnnic-table-next__body-cell--sm" data-testid="body-cell">
           <p data-v-fd58013b="" class="unnnic-table-next__body-cell-text" data-testid="body-cell-text">Row 3 Col 2</p>
         </td>
       </a></tr>

--- a/src/components/TableNext/__test__/validation.unit.test.js
+++ b/src/components/TableNext/__test__/validation.unit.test.js
@@ -19,7 +19,14 @@ describe('TableNext props validations', () => {
     it('should throw an error if a header has "size" that is not a positive number', () => {
       const invalidHeaders = [{ content: 'Header 1', size: -1 }];
       expect(() => validateHeaders(invalidHeaders)).toThrow(
-        'Each item in "headers" that contains "size" must assign it as positive number',
+        'Each item in "headers" that contains "size" must assign it as positive number or equals to "auto"',
+      );
+    });
+
+    it('should throw an error if a header has "size" that is a string not equal to "auto"', () => {
+      const invalidHeaders = [{ content: 'Header 1', size: 'invalid' }];
+      expect(() => validateHeaders(invalidHeaders)).toThrow(
+        'Each item in "headers" that contains "size" must assign it as positive number or equals to "auto"',
       );
     });
 

--- a/src/components/TableNext/__test__/validation.unit.test.js
+++ b/src/components/TableNext/__test__/validation.unit.test.js
@@ -9,12 +9,6 @@ describe('TableNext props validations', () => {
       );
     });
 
-    it('should throw an error if headers is an empty array', () => {
-      expect(() => validateHeaders([])).toThrow(
-        'Property headers must not to be an empty array.',
-      );
-    });
-
     it('should throw an error if a header does not have "content" as a string', () => {
       const invalidHeaders = [{ content: 123 }];
       expect(() => validateHeaders(invalidHeaders)).toThrow(

--- a/src/components/TableNext/validation.js
+++ b/src/components/TableNext/validation.js
@@ -26,10 +26,6 @@ export const validateHeaders = (headers) => {
     throw new Error('Property headers needs to be an array.');
   }
 
-  if (headers.length === 0) {
-    throw new Error('Property headers must not to be an empty array.');
-  }
-
   headers.forEach(validateHeader);
 
   return true;

--- a/src/components/TableNext/validation.js
+++ b/src/components/TableNext/validation.js
@@ -4,11 +4,13 @@ const validateHeader = (header) => {
     throw new Error('Each item in "headers" must have "content" as a string.');
   }
 
-  const isSizePositiveNumber =
-    'size' in header && (typeof header.size !== 'number' || header.size < 0);
-  if (isSizePositiveNumber) {
+  const isSizeInvalid =
+    'size' in header &&
+    ((header.size !== 'auto' && typeof header.size !== 'number') ||
+      header.size < 0);
+  if (isSizeInvalid) {
     throw new Error(
-      'Each item in "headers" that contains "size" must assign it as positive number',
+      'Each item in "headers" that contains "size" must assign it as positive number or equals to "auto"',
     );
   }
 

--- a/src/stories/TableNext.stories.js
+++ b/src/stories/TableNext.stories.js
@@ -2,8 +2,9 @@ import UnnnicTableNext from '../components/TableNext/TableNext.vue';
 import UnnnicButton from '../components/Button/Button.vue';
 
 export default {
-  title: 'example/TableNext',
+  title: 'Data Display/TableNext',
   component: UnnnicTableNext,
+  tags: ['autodocs'],
   argTypes: {},
   render: (args) => ({
     components: {
@@ -67,32 +68,41 @@ const addButton = {
   },
 };
 
+const rows = [
+  {
+    content: ['1', 'Alice', '30', 'USA', addButton],
+    link: {
+      url: 'https://weni.ai/',
+      target: '_blank',
+    },
+  },
+  {
+    content: ['2', 'Bob', '25', 'Canada', addButton],
+    link: {
+      url: 'https://weni.ai/',
+    },
+  },
+  {
+    content: ['3', 'Charlie', '35', 'UK', addButton],
+  },
+  {
+    content: ['4', 'Diana', '28', 'Australia', addButton],
+  },
+  {
+    content: ['5', 'Ethan', '22', 'New Zealand', addButton],
+  },
+];
+
 export const Default = {
   args: {
-    rows: [
-      {
-        content: ['1', 'Alice', '30', 'USA', addButton],
-        link: {
-          url: 'https://weni.ai/',
-          target: '_blank',
-        },
-      },
-      {
-        content: ['2', 'Bob', '25', 'Canada', addButton],
-        link: {
-          url: 'https://weni.ai/',
-        },
-      },
-      {
-        content: ['3', 'Charlie', '35', 'UK', addButton],
-      },
-      {
-        content: ['4', 'Diana', '28', 'Australia', addButton],
-      },
-      {
-        content: ['5', 'Ethan', '22', 'New Zealand', addButton],
-      },
-    ],
+    rows,
+  },
+};
+
+export const Medium = {
+  args: {
+    rows,
+    size: 'md',
   },
 };
 

--- a/src/stories/TableNext.stories.js
+++ b/src/stories/TableNext.stories.js
@@ -56,7 +56,7 @@ export default {
           headers: [
             {
               content: 'ID',
-              size: 0.3,
+              size: 'auto',
             },
             {
               content: 'Name',
@@ -69,6 +69,7 @@ export default {
             },
             {
               content: 'Add with friend',
+              size: 0.5,
             },
           ],
           rows: [],

--- a/src/stories/TableNext.stories.js
+++ b/src/stories/TableNext.stories.js
@@ -5,7 +5,43 @@ export default {
   title: 'Data Display/TableNext',
   component: UnnnicTableNext,
   tags: ['autodocs'],
-  argTypes: {},
+  argTypes: {
+    headers: {
+      description:
+        'Array of header items defining the structure of the table header.',
+      control: 'object',
+    },
+    rows: {
+      description: 'Array of row items defining the content of the table rows.',
+      control: 'object',
+    },
+    size: {
+      description:
+        'The size of the table. Options are `sm` for small and `md` for medium.',
+      control: { type: 'select' },
+      options: ['sm', 'md'],
+    },
+    pagination: {
+      description: 'The current page number for pagination.',
+      control: 'number',
+    },
+    paginationTotal: {
+      description: 'The total number of pages available for pagination.',
+      control: 'number',
+    },
+    paginationInterval: {
+      description: 'The number of items displayed per page.',
+      control: 'number',
+    },
+    isLoading: {
+      description: 'Indicates whether the table data is loading.',
+      control: 'boolean',
+    },
+    hideHeaders: {
+      description: 'Determines if the table headers should be hidden.',
+      control: 'boolean',
+    },
+  },
   render: (args) => ({
     components: {
       UnnnicTableNext,
@@ -103,6 +139,13 @@ export const Medium = {
   args: {
     rows,
     size: 'md',
+  },
+};
+
+export const HideHeaders = {
+  args: {
+    rows,
+    hideHeaders: true,
   },
 };
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Add table variations with medium size, no header and "auto" column size.

### Summary of Changes
- Added `hideHeaders` and `size` props;
- Added the possibility of column sizes being 'auto';
- Improved TableNext documentation;
- Removed the requirement to pass the `headers` prop.
