### PR TITLE
[NEXUS-2590] - Drawer giant size and customized title

### DIFF
--- a/src/components/Drawer/Drawer.vue
+++ b/src/components/Drawer/Drawer.vue
@@ -40,7 +40,6 @@
               >
                 {{ description }}
               </p>
-
             </template>
           </section>
           <UnnnicIcon
@@ -137,7 +136,7 @@ export default {
       type: String,
       default: 'md',
       validator(val) {
-        return ['md', 'lg', 'xl'].includes(val);
+        return ['md', 'lg', 'xl', 'gt'].includes(val);
       },
     },
     wide: {
@@ -268,6 +267,10 @@ export default {
   }
 
   &--xl {
+    width: 66%;
+  }
+
+  &--gt {
     width: 75%;
   }
 

--- a/src/components/Drawer/Drawer.vue
+++ b/src/components/Drawer/Drawer.vue
@@ -24,19 +24,24 @@
       >
         <header class="unnnic-drawer__header">
           <section class="unnnic-drawer__title-container">
-            <h1
-              class="unnnic-drawer__title"
-              data-testid="drawer-title"
-            >
-              {{ title }}
-            </h1>
-            <p
-              v-if="description"
-              class="unnnic-drawer__description"
-              data-testid="drawer-description"
-            >
-              {{ description }}
-            </p>
+            <slot v-if="$slots.title" name="title"/>
+
+            <template v-else>
+              <h1
+                class="unnnic-drawer__title"
+                data-testid="drawer-title"
+              >
+                {{ title }}
+              </h1>
+              <p
+                v-if="description"
+                class="unnnic-drawer__description"
+                data-testid="drawer-description"
+              >
+                {{ description }}
+              </p>
+
+            </template>
           </section>
           <UnnnicIcon
             class="unnnic-drawer__close"

--- a/src/components/Drawer/__tests__/Drawer.spec.js
+++ b/src/components/Drawer/__tests__/Drawer.spec.js
@@ -1,7 +1,6 @@
-import { flushPromises, mount } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import Drawer from '../Drawer.vue';
-import { nextTick } from 'vue';
 
 describe('Drawer.vue', () => {
   let wrapper;
@@ -83,6 +82,37 @@ describe('Drawer.vue', () => {
         expect(wrapper.find('[data-testid="slot-content"]').text()).toBe(
           'Slot Content',
         );
+      });
+
+      it('should render custom title content when using title slot', () => {
+        wrapper = mount(Drawer, {
+          props: {
+            modelValue: true,
+            title: 'Default Title',
+          },
+          slots: {
+            title: '<h2 data-testid="custom-title">Custom Title Content</h2>',
+          },
+        });
+
+        expect(title().exists()).toBe(false);
+        expect(wrapper.find('[data-testid="custom-title"]').exists()).toBe(true);
+        expect(wrapper.find('[data-testid="custom-title"]').text()).toBe('Custom Title Content');
+      });
+
+      it('should prioritize title slot over title prop', () => {
+        wrapper = mount(Drawer, {
+          props: {
+            modelValue: true,
+            title: 'Prop Title',
+          },
+          slots: {
+            title: '<div data-testid="custom-title">Slot Title</div>',
+          },
+        });
+
+        expect(title().exists()).toBe(false);
+        expect(wrapper.find('[data-testid="custom-title"]').text()).toBe('Slot Title');
       });
     });
   });
@@ -242,12 +272,14 @@ describe('Drawer.vue', () => {
       expect(closeIcon().props('icon')).toBe('custom_close_icon');
     });
 
-    it('should validate size prop to accept only md, lg, or xl values', async () => {
+    it('should validate all size prop values correctly', () => {
       const validator = Drawer.props.size.validator;
       expect(validator('md')).toBe(true);
       expect(validator('lg')).toBe(true);
       expect(validator('xl')).toBe(true);
+      expect(validator('gt')).toBe(true);
       expect(validator('sm')).toBe(false);
+      expect(validator('invalid')).toBe(false);
     });
   });
 });

--- a/src/stories/Drawer.stories.js
+++ b/src/stories/Drawer.stories.js
@@ -31,7 +31,7 @@ export default {
     secondaryButtonText: { control: { type: 'text' } },
     modelValue: { control: { type: 'boolean' } },
     size: {
-      options: ['md', 'lg', 'xl'],
+      options: ['md', 'lg', 'xl', 'gt'],
       control: { type: 'select' },
     },
     withoutOverlay: { control: { type: 'boolean' } },
@@ -101,6 +101,16 @@ export const ExtraLarge = {
     primaryButtonText: 'Confirmar',
     secondaryButtonText: 'Cancelar',
     size: 'xl',
+  },
+};
+
+export const Giant = {
+  args: {
+    title: 'Title',
+    description: 'Description',
+    primaryButtonText: 'Confirmar',
+    secondaryButtonText: 'Cancelar',
+    size: 'gt',
   },
 };
 

--- a/src/stories/Drawer.stories.js
+++ b/src/stories/Drawer.stories.js
@@ -2,6 +2,7 @@ import { action } from '@storybook/addon-actions';
 
 import UnnnicDrawer from '../components/Drawer/Drawer.vue';
 import UnnnicButton from '../components/Button/Button.vue';
+import UnnnicAvatarIcon from '../components/AvatarIcon/AvatarIcon.vue';
 
 const primaryButtonTypeOptions = [
   'primary',
@@ -189,5 +190,42 @@ export const WithoutOverlay = {
     primaryButtonText: 'Confirmar',
     secondaryButtonText: 'Cancelar',
     withoutOverlay: true,
+  },
+};
+
+export const TitleModified = {
+  render: (args) => ({
+    components: { UnnnicDrawer, UnnnicAvatarIcon },
+    setup() {
+      return { args };
+    },
+    data() {
+      return {
+        opened: false,
+      };
+    },
+    template: `
+      <div>
+        <pre>v-model: {{ opened }}</pre>
+        <button @click="opened = !opened">Change</button>
+        <unnnic-drawer v-bind="args" v-model="opened" @close="opened = false">
+          <template #title>
+            <section style="display: flex; align-items: center; gap: 8px;">
+              <UnnnicAvatarIcon
+                size="sm"
+                icon="bolt"
+                scheme="aux-blue"
+              />
+              <h1 style="fontSize: 20px; margin: 0;">Modified Title</h1>
+            </section>
+          </template>
+        </unnnic-drawer>
+      </div>
+    `,
+  }),
+  args: {
+    title: 'Title',
+    description: 'Description',
+    size: 'lg',
   },
 };


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
For Agent Builder 2.0, the design required the drawer with 66% of width and customized title.

### Summary of Changes
- Added Drawer customized slot title;
- Added giant variation to Drawer;
- Enhance Drawer component test coverage.

### Demonstration <!--- (If not appropriate, remove this topic) -->
![image](https://github.com/user-attachments/assets/d1d78ba1-36a3-4220-a4b3-2511a43539b6)
