### PR TITLE
[NEXUS-2683] - Add new initial 'next' type to UnnnicTag component

### DIFF
--- a/src/components/Tag/Tag.vue
+++ b/src/components/Tag/Tag.vue
@@ -21,6 +21,7 @@
 import DefaultTag from './DefaultTag.vue';
 import IndicatorTag from './IndicatorTag.vue';
 import BrandTag from './BrandTag.vue';
+import TagNext from './TagNext.vue';
 
 export default {
   name: 'UnnnicTag',
@@ -29,7 +30,7 @@ export default {
       type: String,
       default: 'default',
       validator(value) {
-        return ['default', 'indicator', 'brand'].indexOf(value) !== -1;
+        return ['default', 'indicator', 'brand', 'next'].indexOf(value) !== -1;
       },
     },
     text: {
@@ -81,6 +82,7 @@ export default {
     currentComponent() {
       if (this.type === 'indicator') return IndicatorTag;
       if (this.type === 'brand') return BrandTag;
+      if (this.type === 'next') return TagNext;
       return DefaultTag;
     },
   },

--- a/src/components/Tag/TagNext.vue
+++ b/src/components/Tag/TagNext.vue
@@ -1,0 +1,66 @@
+<template>
+  <section 
+    :class="[
+      'unnnic-tag-next',
+      `unnnic-tag-next--${scheme}`
+    ]"
+  >
+    <p class="unnnic-tag-next__text">
+      {{ text }}
+    </p>
+  </section>
+</template>
+
+<script>
+export default {
+  name: 'TagNext',
+  props: {
+    text: {
+      type: String,
+      default: null,
+    },
+    scheme: {
+      type: String,
+      default: 'weni',
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/unnnic' as *;
+
+.unnnic-tag-next {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: auto;
+
+  border-radius: $unnnic-border-radius-pill;
+  padding: 0 $unnnic-spacing-xs;
+
+  font-family: $unnnic-font-family-secondary;
+  font-size: $unnnic-font-size-body-md;
+  font-weight: $unnnic-font-weight-regular;
+  line-height: ($unnnic-font-size-body-md + $unnnic-line-height-medium);
+
+  &__text {
+    margin: 0;
+
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  &--aux-purple {
+    background-color: $unnnic-color-aux-purple-100;
+    color: $unnnic-color-aux-purple-500;
+  }
+
+  &--weni {
+    background-color: $unnnic-color-weni-100;
+    color: $unnnic-color-weni-600;
+  }
+
+}
+</style> 

--- a/src/stories/Tag.stories.js
+++ b/src/stories/Tag.stories.js
@@ -50,6 +50,14 @@ export const CloseIcon = {
   },
 };
 
+export const Next = {
+  args: {
+    text: 'Label',
+    type: 'next',
+    scheme: 'weni',
+  },
+};
+
 export const Indicator = {
   args: {
     text: 'Tag Name',


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
To cover some new features, it was necessary to add a new style for the tag component. This PR is only covering a few use cases, such as the weni and purple schema. The idea is that we will later come back to this variation to make it the new version of the Tag component.

### Summary of Changes
Add new initial 'next' type to UnnnicTag component.

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File](https://www.figma.com/design/FGfl8EmJCNMz45TX1s3XQO/Agents-Builder-2.0?node-id=1846-11421&m=dev)

### Demonstration <!--- (If not appropriate, remove this topic) -->
![image](https://github.com/user-attachments/assets/5d9a0289-1285-42a3-9838-c0ae27900e1f)
