### PR TITLE
[CFE-738] - Fix dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@ FROM node:22.17.1-alpine3.22 as builder
 
 WORKDIR /home/app
 
-COPY ./package.json ./
+COPY ./package.json ./yarn.lock ./
 
-RUN npm i
+RUN npm install -g yarn && yarn install
 
 COPY . .
 
-RUN npm run build-storybook
+RUN yarn build-storybook
 
 FROM nginxinc/nginx-unprivileged:1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /home/app
 
 COPY ./package.json ./yarn.lock ./
 
-RUN npm install -g yarn && yarn install
+RUN yarn install
 
 COPY . .
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

## **Motivation and Context**
The Docker build was failing with a dependency resolution conflict. This caused the build pipeline to fail in the `build-unnnic-push-tag-shared.yaml` workflow, preventing successful Docker image creation and deployment.

## **Summary of Changes**

Dockerfile Updates: 
- **Changed package manager**: Switched from `npm` to `yarn` to maintain consistency with another workflows (Yarn resolves to compatible versions (@typescript-eslint/parser v8.43.0) while npm attempts to install incompatible versions)
