### PR TITLE
feat: Drawer and Dialog lazy unmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 3.25.4 (2026-04-24)
+
+### Added
+
+- **UnnnicDrawerNext**, **UnnnicDialog**, and **UnnnicDrawer** (legacy): optional `lazyMount` (default `false`) and `unmountDelay` (default `300` ms) on the root wrappers. When `lazyMount` is enabled, `DrawerRoot` / `DialogRoot` (and portal content) mount only after `open` becomes `true` the first time; on close, the tree stays mounted for `unmountDelay` so exit animations from reka-ui / vaul-vue complete before unmount. Reopening remounts the overlay.
+
+### Fixed
+
+- **UnnnicDrawerContent** and **UnnnicDialogContent**: `inheritAttrs: false` with attributes merged into the inner `DrawerContent` / `DialogContent` so extras (e.g. `data-testid`) no longer hit the portal / Teleport fragment and no longer trigger Vue’s “Extraneous non-prop attributes … could not be automatically inherited” warning per instance.
+
 # 3.25.3 (2026-04-01)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weni/unnnic-system",
-  "version": "3.25.3",
+  "version": "3.25.4",
   "type": "commonjs",
   "files": [
     "dist",

--- a/src/components/Drawer/Drawer.vue
+++ b/src/components/Drawer/Drawer.vue
@@ -3,6 +3,8 @@
     class="unnnic-drawer"
     data-testid="drawer"
     :open="modelValue"
+    :lazyMount="lazyMount"
+    :unmountDelay="unmountDelay"
     @update:open="$event ? () => {} : back()"
   >
     <DrawerContent
@@ -10,11 +12,15 @@
       :showOverlay="!withoutOverlay"
       data-testid="drawer-container"
       :size="mappedSize"
-      :class="[
-        'unnnic-drawer__container',
-        `unnnic-drawer__container--${size}`,
-        props.class,
-      ].filter(Boolean).join(' ')"
+      :class="
+        [
+          'unnnic-drawer__container',
+          `unnnic-drawer__container--${size}`,
+          props.class,
+        ]
+          .filter(Boolean)
+          .join(' ')
+      "
     >
       <DrawerHeader class="unnnic-drawer__header">
         <section class="unnnic-drawer__title-container">
@@ -91,7 +97,7 @@
 import { computed } from 'vue';
 
 import UnnnicButton from '../Button/Button.vue';
-import { 
+import {
   Drawer,
   DrawerContent,
   DrawerHeader,
@@ -154,6 +160,14 @@ const props = defineProps({
     type: Boolean,
     required: true,
   },
+  lazyMount: {
+    type: Boolean,
+    default: false,
+  },
+  unmountDelay: {
+    type: Number,
+    default: 300,
+  },
   withoutOverlay: {
     type: Boolean,
     default: false,
@@ -172,15 +186,22 @@ const props = defineProps({
   },
 });
 
-const emit = defineEmits(['primaryButtonClick', 'secondaryButtonClick', 'close', 'back']);
-const showFooter = computed(() => !!(props.primaryButtonText || props.secondaryButtonText));
+const emit = defineEmits([
+  'primaryButtonClick',
+  'secondaryButtonClick',
+  'close',
+  'back',
+]);
+const showFooter = computed(
+  () => !!(props.primaryButtonText || props.secondaryButtonText),
+);
 const mappedSize = computed(() => {
   const sizes = {
     md: 'medium',
     lg: 'large',
     xl: 'extra-large',
     gt: 'giant',
-  }
+  };
   return sizes[props.size] || 'medium';
 });
 

--- a/src/components/Drawer/__tests__/__snapshots__/Drawer.spec.js.snap
+++ b/src/components/Drawer/__tests__/__snapshots__/Drawer.spec.js.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Drawer.vue > Component Rendering > Component Rendering > matches the snapshot 1`] = `
-"<div data-v-196de012="" class="unnnic-drawer" data-testid="drawer" open="true">
+"<div data-v-196de012="" class="unnnic-drawer" data-testid="drawer" open="true" lazymount="false" unmountdelay="300">
   <div data-v-196de012="" showoverlay="true" data-testid="drawer-container" size="medium" class="unnnic-drawer__container unnnic-drawer__container--md">
     <header data-v-39d0dfb8="" data-v-196de012="" class="unnnic-drawer__header unnnic-drawer__header">
       <section data-v-196de012="" class="unnnic-drawer__title-container">

--- a/src/components/ui/dialog/Dialog.vue
+++ b/src/components/ui/dialog/Dialog.vue
@@ -1,19 +1,51 @@
 <script setup lang="ts">
 import type { DialogRootEmits, DialogRootProps } from 'reka-ui';
+import { computed, toRef } from 'vue';
+import { reactiveOmit } from '@vueuse/core';
 import { DialogRoot, useForwardPropsEmits } from 'reka-ui';
+import useDelayedUnmount from '@/composables/useDelayedUnmount';
 
 defineOptions({
   name: 'UnnnicDialog',
 });
 
-const props = defineProps<DialogRootProps>();
+const props = withDefaults(
+  defineProps<
+    DialogRootProps & {
+      /**
+       * When true, the dialog is only mounted while open and stays mounted for
+       * `unmountDelay` ms after closing so the exit animation can play. Use it
+       * to avoid mounting many dialogs eagerly inside lists.
+       */
+      lazyMount?: boolean;
+      /**
+       * Delay (ms) before the dialog is unmounted after closing. Should match
+       * the leave animation duration. Only applies when `lazyMount` is true.
+       */
+      unmountDelay?: number;
+    }
+  >(),
+  {
+    lazyMount: false,
+    unmountDelay: 300,
+  },
+);
 const emits = defineEmits<DialogRootEmits>();
 
-const forwarded = useForwardPropsEmits(props, emits);
+const delegatedProps = reactiveOmit(props, 'lazyMount', 'unmountDelay');
+const forwarded = useForwardPropsEmits(delegatedProps, emits);
+
+const open = toRef(props, 'open');
+const lazyShouldRender = useDelayedUnmount(open, props.unmountDelay);
+
+const shouldRender = computed(() => !props.lazyMount || lazyShouldRender.value);
 </script>
 
 <template>
-  <DialogRoot v-bind="forwarded">
+  <DialogRoot
+    v-if="shouldRender"
+    v-bind="forwarded"
+  >
     <slot />
   </DialogRoot>
 </template>

--- a/src/components/ui/dialog/DialogContent.vue
+++ b/src/components/ui/dialog/DialogContent.vue
@@ -15,6 +15,7 @@ import { useTeleportTarget } from '@/lib/teleport-target';
 
 defineOptions({
   name: 'UnnnicDialogContent',
+  inheritAttrs: false,
 });
 
 const props = withDefaults(
@@ -69,7 +70,7 @@ const ConditionalWrapper: Component = (_, { slots }) => {
 
     <ConditionalWrapper>
       <DialogContent
-        v-bind="forwarded"
+        v-bind="{ ...forwarded, ...$attrs }"
         :class="contentClasses"
         :style="{ zIndex: modalZIndex }"
       >

--- a/src/components/ui/drawer/Drawer.vue
+++ b/src/components/ui/drawer/Drawer.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { DrawerRootEmits, DrawerRootProps } from 'vaul-vue';
+import type { DrawerRootEmits } from 'vaul-vue';
 import { computed, toRef } from 'vue';
 import { reactiveOmit } from '@vueuse/core';
 import { useForwardPropsEmits } from 'reka-ui';
@@ -10,7 +10,34 @@ defineOptions({
   name: 'UnnnicDrawerNext',
 });
 
-interface UnnnicDrawerNextProps extends DrawerRootProps {
+/**
+ * Self-contained props type that mirrors `vaul-vue`'s `DrawerRootProps`.
+ *
+ * We intentionally avoid extending or intersecting `DrawerRootProps` because
+ * its definition includes the internal, non-exported `WithoutFadeFromProps`
+ * type, which breaks `vite-plugin-dts` declaration rollup with TS4023 when
+ * combined with our extra `lazyMount` / `unmountDelay` props.
+ */
+interface DrawerRootProps {
+  activeSnapPoint?: number | string | null;
+  closeThreshold?: number;
+  shouldScaleBackground?: boolean;
+  setBackgroundColorOnScale?: boolean;
+  scrollLockTimeout?: number;
+  fixed?: boolean;
+  dismissible?: boolean;
+  modal?: boolean;
+  open?: boolean;
+  defaultOpen?: boolean;
+  nested?: boolean;
+  direction?: 'top' | 'bottom' | 'left' | 'right';
+  noBodyStyles?: boolean;
+  handleOnly?: boolean;
+  preventScrollRestoration?: boolean;
+  snapPoints?: (number | string)[];
+}
+
+export interface UnnnicDrawerNextProps extends DrawerRootProps {
   /**
    * When true, the drawer is only mounted while open and stays mounted for
    * `unmountDelay` ms after closing so the exit animation can play. Use it
@@ -36,10 +63,8 @@ const delegatedProps = reactiveOmit(props, 'lazyMount', 'unmountDelay');
 const forwarded = useForwardPropsEmits(delegatedProps, emits);
 
 const open = toRef(props, 'open');
-// @ts-expect-error - unmountDelay conflict with the DrawerRootProps type
 const lazyShouldRender = useDelayedUnmount(open, props.unmountDelay);
 
-// @ts-expect-error - lazyMount conflict with the DrawerRootProps type
 const shouldRender = computed(() => !props.lazyMount || lazyShouldRender.value);
 </script>
 

--- a/src/components/ui/drawer/Drawer.vue
+++ b/src/components/ui/drawer/Drawer.vue
@@ -1,23 +1,51 @@
 <script lang="ts" setup>
 import type { DrawerRootEmits, DrawerRootProps } from 'vaul-vue';
+import { computed, toRef } from 'vue';
+import { reactiveOmit } from '@vueuse/core';
 import { useForwardPropsEmits } from 'reka-ui';
 import { DrawerRoot } from 'vaul-vue';
+import useDelayedUnmount from '@/composables/useDelayedUnmount';
 
 defineOptions({
   name: 'UnnnicDrawerNext',
 });
 
-const props = withDefaults(defineProps<DrawerRootProps>(), {
+interface UnnnicDrawerNextProps extends DrawerRootProps {
+  /**
+   * When true, the drawer is only mounted while open and stays mounted for
+   * `unmountDelay` ms after closing so the exit animation can play. Use it
+   * to avoid mounting many drawers eagerly inside lists.
+   */
+  lazyMount?: boolean;
+  /**
+   * Delay (ms) before the drawer is unmounted after closing. Should match
+   * the leave animation duration. Only applies when `lazyMount` is true.
+   */
+  unmountDelay?: number;
+}
+
+const props = withDefaults(defineProps<UnnnicDrawerNextProps>(), {
   shouldScaleBackground: true,
+  lazyMount: false,
+  unmountDelay: 300,
 });
 
 const emits = defineEmits<DrawerRootEmits>();
 
-const forwarded = useForwardPropsEmits(props, emits);
+const delegatedProps = reactiveOmit(props, 'lazyMount', 'unmountDelay');
+const forwarded = useForwardPropsEmits(delegatedProps, emits);
+
+const open = toRef(props, 'open');
+// @ts-expect-error - unmountDelay conflict with the DrawerRootProps type
+const lazyShouldRender = useDelayedUnmount(open, props.unmountDelay);
+
+// @ts-expect-error - lazyMount conflict with the DrawerRootProps type
+const shouldRender = computed(() => !props.lazyMount || lazyShouldRender.value);
 </script>
 
 <template>
   <DrawerRoot
+    v-if="shouldRender"
     v-bind="forwarded"
     direction="right"
     handleOnly

--- a/src/components/ui/drawer/DrawerContent.vue
+++ b/src/components/ui/drawer/DrawerContent.vue
@@ -11,6 +11,7 @@ import DrawerOverlay from './DrawerOverlay.vue';
 
 defineOptions({
   name: 'UnnnicDrawerContent',
+  inheritAttrs: false,
 });
 
 const props = withDefaults(
@@ -43,7 +44,7 @@ const portalTarget = useTeleportTarget();
       :style="{ zIndex: layerZIndex - 2 }"
     />
     <DrawerContent
-      v-bind="forwardedProps"
+      v-bind="{ ...forwardedProps, ...$attrs }"
       :class="
         cn(
           'unnnic-drawer__content',

--- a/src/composables/useDelayedUnmount.ts
+++ b/src/composables/useDelayedUnmount.ts
@@ -1,0 +1,48 @@
+import { type Ref, onBeforeUnmount, ref, watch } from 'vue';
+
+/**
+ * Keeps an overlay mounted for `delay` ms after it closes so the leave
+ * animation can play, while still allowing lazy mounting on first open.
+ *
+ * Used internally by drawer/dialog components when `lazyMount` is enabled to
+ * preserve their exit animation without keeping every overlay's portal
+ * eagerly mounted in the DOM.
+ */
+export default function useDelayedUnmount(
+  isOpen: Ref<boolean | undefined>,
+  delay = 300,
+): Ref<boolean> {
+  const shouldRender = ref(!!isOpen.value);
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const clearTimer = () => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  watch(
+    isOpen,
+    (open) => {
+      clearTimer();
+
+      if (open) {
+        shouldRender.value = true;
+        return;
+      }
+
+      if (shouldRender.value) {
+        timer = setTimeout(() => {
+          shouldRender.value = false;
+          timer = null;
+        }, delay);
+      }
+    },
+    { immediate: true },
+  );
+
+  onBeforeUnmount(clearTimer);
+
+  return shouldRender;
+}

--- a/src/stories/Dialog.stories.js
+++ b/src/stories/Dialog.stories.js
@@ -46,10 +46,28 @@ export default {
       },
       description: 'The type of the dialog (affects header icon)',
     },
+    lazyMount: {
+      control: { type: 'boolean' },
+      defaultValue: {
+        summary: false,
+      },
+      description:
+        'When true, the dialog is only mounted while open and stays mounted for `unmountDelay` ms after closing so the exit animation can play. Use it to avoid mounting many dialogs eagerly inside lists.',
+    },
+    unmountDelay: {
+      control: { type: 'number' },
+      defaultValue: {
+        summary: 300,
+      },
+      description:
+        'Delay (ms) before the dialog is unmounted after closing. Should match the leave animation duration. Only applies when `lazyMount` is true.',
+    },
   },
   args: {
     size: 'medium',
     type: 'default',
+    lazyMount: false,
+    unmountDelay: 300,
   },
 };
 

--- a/src/stories/DrawerNext.stories.js
+++ b/src/stories/DrawerNext.stories.js
@@ -66,10 +66,28 @@ export default {
       },
       description: 'Whether to show the overlay background',
     },
+    lazyMount: {
+      control: { type: 'boolean' },
+      defaultValue: {
+        summary: false,
+      },
+      description:
+        'When true, the drawer is only mounted while open and stays mounted for `unmountDelay` ms after closing so the exit animation can play. Use it to avoid mounting many drawers eagerly inside lists.',
+    },
+    unmountDelay: {
+      control: { type: 'number' },
+      defaultValue: {
+        summary: 300,
+      },
+      description:
+        'Delay (ms) before the drawer is unmounted after closing. Should match the leave animation duration. Only applies when `lazyMount` is true.',
+    },
   },
   args: {
     size: 'medium',
     showOverlay: true,
+    lazyMount: false,
+    unmountDelay: 300,
   },
 };
 


### PR DESCRIPTION
## Description

### Type of Change

* * [x] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
When many instances of `UnnnicDrawer`, `UnnnicDrawerNext`, or `UnnnicDialog` are mounted on screens with lists (e.g., one overlay per card), three problems arise:

1. **Performance**: each overlay creates its own `Teleport`/`Portal` in the `body` on mount. N cards × M overlays = noticeable lag when opening the screen.
2. **Console flood**: `UnnnicDrawerContent` and `UnnnicDialogContent` pass extra attributes (`data-testid`, etc.) to the internal `DialogPortal`/`DrawerPortal`, which is a fragment (Teleport). Vue triggers `Extraneous non-prop attributes ... could not be automatically inherited because component renders fragment` for each instance.
3. **Cut Animation**: the only way for the consumer to avoid (1) and (2) today is to wrap the overlay in `v-if="isOpen"`, which destroys the component immediately upon closing and kills the exit animation of reka-ui/vaul-vue.

The solution needs to address all three points without breaking existing consumers that already handle the problem in their own way.

### Summary of Changes
#### 1. Elimination of warnings

`UnnnicDrawerContent` and `UnnnicDialogContent` now declare `inheritAttrs: false` and apply `v-bind="{ ...forwardedProps, ...$attrs }"` to the inner `DrawerContent`/`DialogContent`. Extra attributes (including `data-testid`) land on the actual element rendered by the portal, not on the Teleport (fragment).

#### 2. Lazy Mount + Delayed Unmount Opt-in (props `lazyMount` and `unmountDelay`)

New props in the three root wrappers, **default `false`:

- `UnnnicDrawerNext` (`ui/drawer/Drawer.vue`)
- `UnnnicDialog` (`ui/dialog/Dialog.vue`)
- Legacy `UnnnicDrawer` (`Drawer/Drawer.vue`) (declares the props and passes them to `UnnnicDrawerNext`).

When `lazyMount` is active:

- The overlay content (`DrawerRoot`/`DialogRoot` + portal) is **only mounted when `open` becomes `true` for the first time**.
- Upon closing, the component remains mounted for `unmountDelay` ms (default). 300)** so that the Reka-UI/Value exit animation runs normally, and only then is it unmounted.

- Reopening it causes the mount to remount.