### PR TITLE
[ENGAGE-7972] Feat: pending response chats contact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 3.25.6 (2026-05-05)
+
+### Added
+
+- **ChatsContact**: `pendingResponse` (Boolean, default `false`) and `pendingResponseTooltip` (String, default `''`) props. When `pendingResponse` is `true`, a blue `reply` icon (`fg-info`) is rendered in the right-side container, anchored to the edge of the card and placed next to the pin icon when both are active. The optional `pendingResponseTooltip` shows a tooltip on hover; when empty, no tooltip is displayed. Storybook stories `PendingResponse` and `PendingResponsePinned` added.
+
 # 3.25.5 (2026-04-28)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weni/unnnic-system",
-  "version": "3.25.5",
+  "version": "3.25.6",
   "type": "commonjs",
   "files": [
     "dist",

--- a/src/components/ChatsContact/ChatsContact.vue
+++ b/src/components/ChatsContact/ChatsContact.vue
@@ -19,7 +19,7 @@
       }
     "
   >
-   <slot name="avatar">
+    <slot name="avatar">
       <UserAvatar
         v-if="discussionGoal"
         scheme="purple-200"
@@ -106,6 +106,20 @@
       <section
         class="chats-contact__infos__unread-messages-container__pin-container"
       >
+        <UnnnicTooltip
+          v-if="pendingResponse"
+          class="chats-contact__infos__pending-response"
+          :enabled="!!pendingResponseTooltip"
+          :text="pendingResponseTooltip"
+          side="top"
+        >
+          <UnnnicIcon
+            icon="reply"
+            size="sm"
+            scheme="fg-info"
+            data-testid="pending-response-icon"
+          />
+        </UnnnicTooltip>
         <button
           v-if="isRenderPin"
           data-testid="pin-button"
@@ -148,6 +162,7 @@ import UnnnicIcon from '../Icon.vue';
 import TransitionRipple from '../TransitionRipple/TransitionRipple.vue';
 import UnnnicI18n from '../../mixins/i18n';
 import Checkbox from '../Checkbox/Checkbox.vue';
+import UnnnicTooltip from '../ToolTip/ToolTip.vue';
 
 import('moment/dist/locale/es.js');
 import('moment/dist/locale/pt-br.js');
@@ -162,6 +177,7 @@ export default {
     UnnnicIcon,
     TransitionRipple,
     Checkbox,
+    UnnnicTooltip,
   },
 
   mixins: [UnnnicI18n],
@@ -234,6 +250,14 @@ export default {
     schemePin: {
       type: String,
       default: ' fg-base',
+    },
+    pendingResponse: {
+      type: Boolean,
+      default: false,
+    },
+    pendingResponseTooltip: {
+      type: String,
+      default: '',
     },
   },
 
@@ -547,6 +571,11 @@ export default {
       color: $unnnic-color-fg-muted;
     }
 
+    &__pending-response {
+      display: flex;
+      align-items: center;
+    }
+
     &__unread-messages-container {
       height: 100%;
       min-width: max-content;
@@ -560,6 +589,7 @@ export default {
       &__pin-container {
         display: flex;
         align-items: center;
+        gap: $unnnic-spacing-nano;
         position: relative;
         z-index: 10;
       }

--- a/src/components/ChatsContact/ChatsContact.vue
+++ b/src/components/ChatsContact/ChatsContact.vue
@@ -589,7 +589,7 @@ export default {
       &__pin-container {
         display: flex;
         align-items: center;
-        gap: $unnnic-spacing-nano;
+        gap: $unnnic-space-1;
         position: relative;
         z-index: 10;
       }

--- a/src/components/ChatsContact/__tests__/ChatsContact.spec.js
+++ b/src/components/ChatsContact/__tests__/ChatsContact.spec.js
@@ -268,10 +268,10 @@ describe('UnnnicChatsContact', () => {
     it('should render the pending response icon when pendingResponse is true', async () => {
       await wrapper.setProps({ pendingResponse: true });
 
-      const icon = wrapper.find('[data-testid="pending-response-icon"]');
+      const icon = wrapper.findComponent('[data-testid="pending-response-icon"]');
       expect(icon.exists()).toBe(true);
-      expect(icon.attributes('icon')).toBe('reply');
-      expect(icon.attributes('scheme')).toBe('fg-info');
+      expect(icon.props('icon')).toBe('reply');
+      expect(icon.props('scheme')).toBe('fg-info');
     });
 
     it('should keep tooltip disabled when pendingResponseTooltip is empty', async () => {

--- a/src/components/ChatsContact/__tests__/ChatsContact.spec.js
+++ b/src/components/ChatsContact/__tests__/ChatsContact.spec.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, afterEach, test, vi } from 'vitest';
+import { beforeEach, describe, expect, afterEach, it, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 
 import UnnnicChatsContact from '../ChatsContact.vue';
@@ -256,6 +256,48 @@ describe('UnnnicChatsContact', () => {
 
       const pinElement = wrapper.find('[data-testid="pin-button"]');
       expect(pinElement.exists()).toBe(false);
+    });
+  });
+
+  describe('Pending response', () => {
+    it('should not render the pending response icon by default', () => {
+      const icon = wrapper.find('[data-testid="pending-response-icon"]');
+      expect(icon.exists()).toBe(false);
+    });
+
+    it('should render the pending response icon when pendingResponse is true', async () => {
+      await wrapper.setProps({ pendingResponse: true });
+
+      const icon = wrapper.find('[data-testid="pending-response-icon"]');
+      expect(icon.exists()).toBe(true);
+      expect(icon.attributes('icon')).toBe('reply');
+      expect(icon.attributes('scheme')).toBe('fg-info');
+    });
+
+    it('should keep tooltip disabled when pendingResponseTooltip is empty', async () => {
+      await wrapper.setProps({
+        pendingResponse: true,
+        pendingResponseTooltip: '',
+      });
+
+      const tooltip = wrapper.findComponent({ name: 'UnnnicTooltip' });
+      expect(tooltip.exists()).toBe(true);
+      expect(tooltip.props('enabled')).toBe(false);
+      expect(tooltip.props('text')).toBe('');
+    });
+
+    it('should enable tooltip with the provided text when pendingResponseTooltip is set', async () => {
+      const tooltipText = 'You did not respond to this contact';
+
+      await wrapper.setProps({
+        pendingResponse: true,
+        pendingResponseTooltip: tooltipText,
+      });
+
+      const tooltip = wrapper.findComponent({ name: 'UnnnicTooltip' });
+      expect(tooltip.exists()).toBe(true);
+      expect(tooltip.props('enabled')).toBe(true);
+      expect(tooltip.props('text')).toBe(tooltipText);
     });
   });
 });

--- a/src/components/ChatsContact/__tests__/__snapshots__/ChatsContact.spec.js.snap
+++ b/src/components/ChatsContact/__tests__/__snapshots__/ChatsContact.spec.js.snap
@@ -16,6 +16,7 @@ exports[`UnnnicChatsContact > should match snapshot 1`] = `
     <!--v-if-->
     <section data-v-8ce6efd5="" class="chats-contact__infos__unread-messages-container__pin-container">
       <!--v-if-->
+      <!--v-if-->
     </section>
   </section>
   <transition-group-stub data-v-17112bed="" data-v-8ce6efd5="" name="grow" tag="div" appear="false" persisted="false" css="true" class="ripples"></transition-group-stub>

--- a/src/stories/ChatsContact.stories.js
+++ b/src/stories/ChatsContact.stories.js
@@ -135,6 +135,36 @@ export const Discussion = {
   },
 };
 
+export const PendingResponse = {
+  args: {
+    ...defaultArgs,
+    title: 'Aline',
+    projectName: 'Sector name',
+    lastMessage: {
+      text: 'I’d like to know if powdered dishwasher detergent is available',
+    },
+    lastInteractionTime: new Date().toISOString(),
+    pendingResponse: true,
+    pendingResponseTooltip: 'You did not respond to this contact',
+  },
+};
+
+export const PendingResponsePinned = {
+  args: {
+    ...defaultArgs,
+    title: 'Milena',
+    projectName: 'Sector name',
+    lastMessage: {
+      text: 'Okay, I’ll wait for a response regarding the order status',
+    },
+    lastInteractionTime: new Date().toISOString(),
+    pendingResponse: true,
+    pendingResponseTooltip: 'You did not respond to this contact',
+    pinned: true,
+    activePin: true,
+  },
+};
+
 export const ContactList = {
   args: {
     ...defaultArgs,


### PR DESCRIPTION
## Description

### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Implements the new "pending response" indicator on `ChatsContact` to give attendants a clear visual cue when a contact has sent a message that has not been replied to yet, following the latest Live Desk design from Figma.

### Summary of Changes
- Added two new props to `ChatsContact`:
  - `pendingResponse` (Boolean): renders a blue reply icon (`fg-info`) on the right side of the contact card.
  - `pendingResponseTooltip` (String): optional tooltip text shown on hover; when empty, no tooltip is displayed.
- Placed the reply icon inside the existing right-side container (`__pin-container`), so it stays anchored to the right edge of the card and sits next to the pin icon when both are active, matching the Figma design.
- Added a small gap to `__pin-container` to space the reply and pin icons when shown together.
- Preserved all existing behavior: message preview, media preview, waiting time, pin/unpin, unread message counter, last interaction time, checkbox-on-select, and discussion mode were not affected.
- Added two Storybook stories:
  - `PendingResponse`: pending response icon only (Figma variation 1).
  - `PendingResponsePinned`: pending response icon + pinned (Figma variation 2).
- Added unit tests covering: default (icon not rendered), icon rendered when `pendingResponse` is true with correct icon/scheme, tooltip disabled when no text, tooltip enabled with the provided text.
- Updated the existing component snapshot to reflect the new conditional placeholder inside `__pin-container`.
- Note: the "Inactivity" warning shown in the Figma design is intentionally out of scope for this PR and will be implemented separately.