### PR TITLE
[ENGAGE-7975] Feat: chat contact new variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 3.25.7 (2026-05-14)
+
+### Added
+
+- **ChatsContact**: `lastMessage.isFromUser` flag renders a localized "You:" prefix (`en: You:`, `pt-br: Você:`, `es: Tú:`) before the media icon when the last message is a media sent by the agent. Storybook story `MediaLastMessageFromUser` added.
+- **ChatsContact**: `newMessageIndicator` (Boolean, default `false`) and `newMessageIndicatorTooltip` (String, default `''`) props. When `newMessageIndicator` is `true`, an 8 px `bg-blue-strong` dot is rendered in the right-side container in place of the unread-count badge, vertically aligned with the message text row. The optional `newMessageIndicatorTooltip` shows a tooltip on hover (anchored to `top`); when empty, no tooltip is displayed. Storybook stories `NewMessageIndicator` and `NewMessageIndicatorWithTooltip` added.
+
 # 3.25.6 (2026-05-05)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weni/unnnic-system",
-  "version": "3.25.6",
+  "version": "3.25.7",
   "type": "commonjs",
   "files": [
     "dist",

--- a/src/components/ChatsContact/ChatsContact.vue
+++ b/src/components/ChatsContact/ChatsContact.vue
@@ -67,6 +67,13 @@
         </p>
         <template v-else-if="lastMessageMedia.isMedia">
           <section class="chats-contact__infos__media">
+            <p
+              v-if="lastMessage.isFromUser"
+              class="chats-contact__infos__media__sender-prefix"
+              data-testid="media-sender-prefix"
+            >
+              {{ i18n('you_message_prefix') }}
+            </p>
             <UnnnicIcon
               :icon="lastMessageMedia.mediaIcon"
               scheme="fg-base"
@@ -135,6 +142,18 @@
             :scheme="schemePin"
           />
         </button>
+        <UnnnicTooltip
+          v-else-if="newMessageIndicator"
+          class="chats-contact__infos__new-message-indicator-tooltip"
+          :enabled="!!newMessageIndicatorTooltip"
+          :text="newMessageIndicatorTooltip"
+          side="top"
+        >
+          <span
+            class="chats-contact__infos__new-message-indicator"
+            data-testid="new-message-indicator"
+          />
+        </UnnnicTooltip>
         <p
           v-else-if="(unreadMessages && !selected) || forceShowUnreadMessages"
           class="chats-contact__infos__unread-messages"
@@ -259,6 +278,14 @@ export default {
       type: String,
       default: '',
     },
+    newMessageIndicator: {
+      type: Boolean,
+      default: false,
+    },
+    newMessageIndicatorTooltip: {
+      type: String,
+      default: '',
+    },
   },
 
   emits: ['click', 'clickPin'],
@@ -309,12 +336,18 @@ export default {
           en: 'Video',
           es: 'Video',
         },
+        you_message_prefix: {
+          'pt-br': 'Você:',
+          en: 'You:',
+          es: 'Tú:',
+        },
       },
     };
   },
 
   computed: {
     messageInfoAlign() {
+      if (this.newMessageIndicator) return 'space-between';
       return this.unreadMessages && this.selected ? 'center' : 'flex-start';
     },
     messageInfoMarginTop() {
@@ -552,6 +585,10 @@ export default {
       display: flex;
       align-items: center;
       gap: $unnnic-spacing-nano;
+
+      &__sender-prefix {
+        color: $unnnic-color-fg-base;
+      }
     }
 
     &__title,
@@ -645,6 +682,27 @@ export default {
       font-weight: $unnnic-font-weight-bold;
       line-height: $unnnic-line-height-small;
       color: $unnnic-color-weni-700;
+    }
+
+    &__new-message-indicator {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+
+      width: $unnnic-space-5;
+      min-width: $unnnic-space-5;
+      height: $unnnic-space-5;
+
+      &::before {
+        content: '';
+        display: block;
+
+        width: $unnnic-space-2;
+        height: $unnnic-space-2;
+
+        border-radius: 50%;
+        background-color: $unnnic-color-bg-blue-strong;
+      }
     }
 
     .ellipsis {

--- a/src/components/ChatsContact/__tests__/ChatsContact.spec.js
+++ b/src/components/ChatsContact/__tests__/ChatsContact.spec.js
@@ -259,6 +259,125 @@ describe('UnnnicChatsContact', () => {
     });
   });
 
+  describe('Media "You:" prefix', () => {
+    const imageMedia = {
+      media: [
+        {
+          content_type: 'image/jpeg',
+          message: 'a997421d-6238-4bef-912d-e689c1c0db3f',
+          url: 'https://example.com/photo.jpg',
+          created_on: '2025-04-15T14:58:56.163027-03:00',
+        },
+      ],
+    };
+
+    it('should not render the prefix on a media message when isFromUser is falsy', async () => {
+      await wrapper.setProps({ lastMessage: imageMedia });
+
+      const prefix = wrapper.find('[data-testid="media-sender-prefix"]');
+      expect(prefix.exists()).toBe(false);
+    });
+
+    it('should render the EN "You:" prefix when isFromUser is true', async () => {
+      await wrapper.setProps({
+        lastMessage: { ...imageMedia, isFromUser: true },
+        locale: 'en',
+      });
+
+      const prefix = wrapper.find('[data-testid="media-sender-prefix"]');
+      expect(prefix.exists()).toBe(true);
+      expect(prefix.text()).toBe('You:');
+    });
+
+    it('should render the PT-BR "Você:" prefix when isFromUser is true', async () => {
+      await wrapper.setProps({
+        lastMessage: { ...imageMedia, isFromUser: true },
+        locale: 'pt-br',
+      });
+
+      const prefix = wrapper.find('[data-testid="media-sender-prefix"]');
+      expect(prefix.exists()).toBe(true);
+      expect(prefix.text()).toBe('Você:');
+    });
+
+    it('should render the ES "Tú:" prefix when isFromUser is true', async () => {
+      await wrapper.setProps({
+        lastMessage: { ...imageMedia, isFromUser: true },
+        locale: 'es',
+      });
+
+      const prefix = wrapper.find('[data-testid="media-sender-prefix"]');
+      expect(prefix.exists()).toBe(true);
+      expect(prefix.text()).toBe('Tú:');
+    });
+
+    it('should not render the prefix for non-media messages even when isFromUser is true', async () => {
+      await wrapper.setProps({
+        lastMessage: { text: 'Hello there', isFromUser: true },
+      });
+
+      const prefix = wrapper.find('[data-testid="media-sender-prefix"]');
+      expect(prefix.exists()).toBe(false);
+    });
+  });
+
+  describe('New message indicator', () => {
+    it('should not render the dot by default', () => {
+      const indicator = wrapper.find('[data-testid="new-message-indicator"]');
+      expect(indicator.exists()).toBe(false);
+    });
+
+    it('should render the dot when newMessageIndicator is true', async () => {
+      await wrapper.setProps({ newMessageIndicator: true });
+
+      const indicator = wrapper.find('[data-testid="new-message-indicator"]');
+      expect(indicator.exists()).toBe(true);
+    });
+
+    it('should hide the unread-count circle when newMessageIndicator and unreadMessages are both set', async () => {
+      await wrapper.setProps({
+        newMessageIndicator: true,
+        unreadMessages: 5,
+      });
+
+      const indicator = wrapper.find('[data-testid="new-message-indicator"]');
+      const unreadCount = wrapper.find(
+        '.chats-contact__infos__unread-messages',
+      );
+
+      expect(indicator.exists()).toBe(true);
+      expect(unreadCount.exists()).toBe(false);
+    });
+
+    it('should keep tooltip disabled when newMessageIndicatorTooltip is empty', async () => {
+      await wrapper.setProps({
+        newMessageIndicator: true,
+        newMessageIndicatorTooltip: '',
+      });
+
+      const tooltip = wrapper.findComponent({ name: 'UnnnicTooltip' });
+
+      expect(tooltip.exists()).toBe(true);
+      expect(tooltip.props('enabled')).toBe(false);
+      expect(tooltip.props('text')).toBe('');
+    });
+
+    it('should enable tooltip with the provided text when newMessageIndicatorTooltip is set', async () => {
+      const tooltipText = 'New chats received';
+
+      await wrapper.setProps({
+        newMessageIndicator: true,
+        newMessageIndicatorTooltip: tooltipText,
+      });
+
+      const tooltip = wrapper.findComponent({ name: 'UnnnicTooltip' });
+
+      expect(tooltip.exists()).toBe(true);
+      expect(tooltip.props('enabled')).toBe(true);
+      expect(tooltip.props('text')).toBe(tooltipText);
+    });
+  });
+
   describe('Pending response', () => {
     it('should not render the pending response icon by default', () => {
       const icon = wrapper.find('[data-testid="pending-response-icon"]');
@@ -268,7 +387,9 @@ describe('UnnnicChatsContact', () => {
     it('should render the pending response icon when pendingResponse is true', async () => {
       await wrapper.setProps({ pendingResponse: true });
 
-      const icon = wrapper.findComponent('[data-testid="pending-response-icon"]');
+      const icon = wrapper.findComponent(
+        '[data-testid="pending-response-icon"]',
+      );
       expect(icon.exists()).toBe(true);
       expect(icon.props('icon')).toBe('reply');
       expect(icon.props('scheme')).toBe('fg-info');

--- a/src/stories/ChatsContact.stories.js
+++ b/src/stories/ChatsContact.stories.js
@@ -220,3 +220,56 @@ export const MediaLastMessage = {
   `,
   }),
 };
+
+const lastMessageMediaFromUser = Object.fromEntries(
+  Object.entries(lastMessageMedia).map(([mediaType, message]) => [
+    mediaType,
+    { ...message, isFromUser: true },
+  ]),
+);
+
+export const MediaLastMessageFromUser = {
+  args: {
+    ...defaultArgs,
+  },
+  render: (args) => ({
+    setup() {
+      return { args, lastMessageMediaFromUser };
+    },
+    components: { unnnicChatsContact },
+    template: `
+    <div style="display: grid;">
+      <unnnic-chats-contact v-for="mediaType in ['geo', 'audio', 'image', 'video', 'document']" v-bind="args" :lastMessage="lastMessageMediaFromUser[mediaType]"/>
+    </div>
+  `,
+  }),
+};
+
+export const NewMessageIndicator = {
+  args: {
+    ...defaultArgs,
+    title: 'Aline',
+    projectName: 'Sector name',
+    lastMessage: {
+      text: 'I’d like to know if powdered dishwasher detergent is available',
+    },
+    lastInteractionTime: new Date().toISOString(),
+    unreadMessages: 1,
+    newMessageIndicator: true,
+  },
+};
+
+export const NewMessageIndicatorWithTooltip = {
+  args: {
+    ...defaultArgs,
+    title: 'Aline',
+    projectName: 'Sector name',
+    lastMessage: {
+      text: 'I’d like to know if powdered dishwasher detergent is available',
+    },
+    lastInteractionTime: new Date().toISOString(),
+    unreadMessages: 1,
+    newMessageIndicator: true,
+    newMessageIndicatorTooltip: 'New chats received',
+  },
+};


### PR DESCRIPTION
## Description

### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
The Live Desk redesign requires `ChatsContact` to surface two new states from the contact list:

- Indicate when the last media message in a conversation was sent by the logged-in agent (the "You:" prefix used in messengers like WhatsApp), so attendants can quickly identify their own outbound media.
- Indicate that a chat has new activity using a small blue dot, with an optional tooltip (e.g. "New chats received") on hover, replacing the numeric unread badge for this lighter notification style.

### Summary of Changes
- **ChatsContact (`src/components/ChatsContact/ChatsContact.vue`)**
  - Read a new optional `isFromUser: boolean` field from the existing `lastMessage` prop. When the last message is a media and `isFromUser` is `true`, a localized prefix (`You:` / `Você:` / `Tú:`) is rendered before the media icon.
  - New translation key `you_message_prefix` added to `defaultTranslations` with `en`, `pt-br`, and `es` values.
  - New props `newMessageIndicator: Boolean` (default `false`) and `newMessageIndicatorTooltip: String` (default `''`). When `newMessageIndicator` is `true`, an 8 px dot using the `$unnnic-color-bg-blue-strong` token is rendered in the right-side container, replacing the unread-count badge. The dot is wrapped in `UnnnicTooltip` (`side="top"`, enabled only when `newMessageIndicatorTooltip` is non-empty), mirroring the existing `pendingResponse` pattern.
  - Layout adjusted so the dot sits at the bottom of the right column, vertically aligned with the message-text row (matches Figma): `messageInfoAlign` returns `'space-between'` when `newMessageIndicator` is set. The dot is centered inside a `$unnnic-space-5` (20 px) slot via a `::before` pseudo-element, so it occupies the same horizontal position as the unread-count badge would.
  - Uses only current (non-deprecated) tokens: `$unnnic-color-bg-blue-strong`, `$unnnic-color-fg-base`, `$unnnic-space-2`, `$unnnic-space-5`, `$unnnic-spacing-nano`.
- **Tests (`src/components/ChatsContact/__tests__/ChatsContact.spec.js`)**
  - New `Media "You:" prefix` block: prefix hidden by default, rendered with the correct EN / PT-BR / ES copy when `isFromUser` is `true`, and not rendered for text-only messages.
  - New `New message indicator` block: dot hidden by default, rendered when `newMessageIndicator` is `true`, hides the unread-count badge when both are set, tooltip disabled when text is empty and enabled with the provided text.
  - All 30 tests passing; existing snapshot remains valid.
- **Stories (`src/stories/ChatsContact.stories.js`)**: added `MediaLastMessageFromUser`, `NewMessageIndicator`, and `NewMessageIndicatorWithTooltip` stories that match the Figma examples.
- **CHANGELOG**: added entry under `3.25.7 (2026-05-14)` describing the two new variations and the new props/translation.

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File](https://www.figma.com/design/IAXGYmgDyjLzHavOtX0ram/Live-Desk----General-improvements--2026-?node-id=1207-6964&t=BHZ9ZJyIA2fJZoIU-1)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->
<img width="260" height="107" alt="image" src="https://github.com/user-attachments/assets/d1b4446c-349e-4030-aa94-d3733fe72f09" />
<img width="260" height="107" alt="image" src="https://github.com/user-attachments/assets/d1b4446c-349e-4030-aa94-d3733fe72f09" />
