### PR TITLE
chore: Bump version to 3.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 3.27.0 (2026-05-28)
+
+### Changed
+
+- **UnnnicDrawerFooter** and **UnnnicDialogFooter**: Footer actions aligned to the right; direct children no longer stretch to full width.
+- **UnnnicDrawer** (legacy): Removed duplicate footer layout rules now handled by `UnnnicDrawerFooter`.
+
 # 3.26.1 (2026-05-20)
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weni/unnnic-system",
-  "version": "3.26.1",
+  "version": "3.27.0",
   "type": "commonjs",
   "files": [
     "dist",


### PR DESCRIPTION
## Description

### Type of Change
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [x] Other

### Motivation and Context
Release `3.27.0` documents the Drawer and Dialog footer redesign merged in [#799](https://github.com/weni-ai/unnnic/pull/799). Footer actions are now right-aligned per the updated Unnnic design specs.

### Summary of Changes
- Bump `@weni/unnnic-system` version to `3.27.0` in `package.json`
- Add `3.27.0 (2026-05-28)` entry to `CHANGELOG.md` under **Changed**:
  - **UnnnicDrawerFooter** and **UnnnicDialogFooter**: footer actions aligned to the right; direct children no longer stretch to full width
  - **UnnnicDrawer** (legacy): removed duplicate footer layout rules now handled by `UnnnicDrawerFooter`