### PR TITLE
style(Toast): improve dark mode background rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 3.27.1 (2026-05-28)
+
+### Fixed
+
+- **UnnnicToast**: Status backgrounds (informational, attention, success, error) now use layered linear gradients so semi-transparent semantic tokens render correctly over `bg-base` in dark mode;
+
 # 3.27.0 (2026-05-28)
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weni/unnnic-system",
-  "version": "3.27.0",
+  "version": "3.27.1",
   "type": "commonjs",
   "files": [
     "dist",

--- a/src/components/Toast/Toast.vue
+++ b/src/components/Toast/Toast.vue
@@ -172,22 +172,25 @@ onUnmounted(() => {
 
   &--informational {
     border-color: $unnnic-color-border-info;
-    background-color: $unnnic-color-bg-info;
+    background: linear-gradient($unnnic-color-bg-info), $unnnic-color-bg-base;
   }
 
   &--attention {
     border-color: $unnnic-color-border-warning;
-    background-color: $unnnic-color-bg-warning;
+    background:
+      linear-gradient($unnnic-color-bg-warning), $unnnic-color-bg-base;
   }
 
   &--success {
     border-color: $unnnic-color-border-success;
-    background-color: $unnnic-color-bg-success;
+    background:
+      linear-gradient($unnnic-color-bg-success), $unnnic-color-bg-base;
   }
 
   &--error {
     border-color: $unnnic-color-border-critical;
-    background-color: $unnnic-color-bg-critical;
+    background:
+      linear-gradient($unnnic-color-bg-critical), $unnnic-color-bg-base;
   }
 
   &__content,


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [x] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When using Toasts in dark mode, content behind the component could still be partially visible due to the transparent background styles, reducing readability and visual consistency.

### Summary of Changes
<!--- Describe your changes in detail -->
Added a solid base background layer behind translucent backgrounds

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->
before:
<img width="325" height="99" alt="image" src="https://github.com/user-attachments/assets/d59b1bdb-4b6d-4887-ad5e-3db5d2d2ab75" />

after:
<img width="329" height="103" alt="image" src="https://github.com/user-attachments/assets/256e078d-5630-4256-a5e8-5584e78d7448" />