### PR TITLE
fix: Enhance slot handling by splitting PopoverContent footer and other popover fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 3.28.1 (2026-06-05)
+
+### Fixed
+
+- **UnnnicPopoverContent**: `UnnnicPopoverFooter` is now detected at any nesting level. Previously only top-level slot children were checked, so a footer wrapped in a container (e.g. `<section>`) was rendered inside `unnnic-popover__content` instead of the dedicated footer area.
+
 # 3.28.0 (2026-06-02)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weni/unnnic-system",
-  "version": "3.27.2",
+  "version": "3.28.1",
   "type": "commonjs",
   "files": [
     "dist",

--- a/src/components/ui/popover/PopoverContent.vue
+++ b/src/components/ui/popover/PopoverContent.vue
@@ -11,17 +11,12 @@
       "
     >
       <section :class="`unnnic-popover__content ${props.class || ''}`">
-        <component
-          :is="child"
-          v-for="(child, index) in contentChildren"
-          :key="index"
-        />
+        <slot />
       </section>
 
-      <component
-        :is="child"
-        v-for="(child, index) in footerChildren"
-        :key="index"
+      <div
+        ref="footerContainer"
+        data-testid="popover-footer-container"
       />
     </PopoverContent>
   </PopoverPortal>
@@ -29,13 +24,14 @@
 
 <script setup lang="ts">
 import type { PopoverContentEmits, PopoverContentProps } from 'reka-ui';
-import type { HTMLAttributes, Slots, VNode } from 'vue';
-import { computed, useSlots } from 'vue';
+import type { HTMLAttributes } from 'vue';
+import { computed, provide, ref } from 'vue';
 import { reactiveOmit } from '@vueuse/core';
 import { PopoverContent, PopoverPortal, useForwardPropsEmits } from 'reka-ui';
 import { cn } from '@/lib/utils';
 import { useLayerZIndex } from '@/lib/layer-manager';
 import { useTeleportTarget } from '@/lib/teleport-target';
+import { POPOVER_FOOTER_TARGET } from './context';
 
 defineOptions({
   inheritAttrs: false,
@@ -63,43 +59,11 @@ const delegatedProps = reactiveOmit(props, 'class', 'size');
 
 const forwarded = useForwardPropsEmits(delegatedProps, emits);
 
-const slots = useSlots() as Slots;
-
 const popoverZIndex = useLayerZIndex();
 const portalTarget = useTeleportTarget();
 
-const getComponentName = (vnode: VNode): string | undefined => {
-  const componentType = vnode.type as { name?: string; __name?: string };
-  return componentType?.name || componentType?.__name;
-};
-
-const isFooter = (vnode: VNode) =>
-  getComponentName(vnode) === 'UnnnicPopoverFooter';
-
-// This function recursively checks if there is a UnnnicPopoverFooter in the slot,
-// and splits the content into content and footer
-const splitSlot = computed(() => {
-  const footers: VNode[] = [];
-
-  const content = (function extract(vnodes: VNode[]): VNode[] {
-    return vnodes.filter((vnode: VNode) => {
-      if (!vnode || typeof vnode !== 'object') return true;
-      if (isFooter(vnode)) return footers.push(vnode) && false;
-
-      if (Array.isArray(vnode.children) && vnode.children.length) {
-        vnode.children = extract(vnode.children as VNode[]);
-        return (vnode.children as VNode[]).length > 0;
-      }
-
-      return true;
-    });
-  })(slots.default?.() || []);
-
-  return { content, footers };
-});
-
-const contentChildren = computed(() => splitSlot.value.content);
-const footerChildren = computed(() => splitSlot.value.footers);
+const footerContainer = ref<HTMLElement | null>(null);
+provide(POPOVER_FOOTER_TARGET, footerContainer);
 
 const contentWidth = computed(() => {
   if (props.width) return props.width;

--- a/src/components/ui/popover/PopoverContent.vue
+++ b/src/components/ui/popover/PopoverContent.vue
@@ -73,19 +73,33 @@ const getComponentName = (vnode: VNode): string | undefined => {
   return componentType?.name || componentType?.__name;
 };
 
-const contentChildren = computed(() => {
-  const defaultSlot = slots.default?.() || [];
-  return defaultSlot.filter(
-    (vnode: VNode) => getComponentName(vnode) !== 'UnnnicPopoverFooter',
-  );
+const isFooter = (vnode: VNode) =>
+  getComponentName(vnode) === 'UnnnicPopoverFooter';
+
+// This function recursively checks if there is a UnnnicPopoverFooter in the slot,
+// and splits the content into content and footer
+const splitSlot = computed(() => {
+  const footers: VNode[] = [];
+
+  const content = (function extract(vnodes: VNode[]): VNode[] {
+    return vnodes.filter((vnode: VNode) => {
+      if (!vnode || typeof vnode !== 'object') return true;
+      if (isFooter(vnode)) return footers.push(vnode) && false;
+
+      if (Array.isArray(vnode.children) && vnode.children.length) {
+        vnode.children = extract(vnode.children as VNode[]);
+        return (vnode.children as VNode[]).length > 0;
+      }
+
+      return true;
+    });
+  })(slots.default?.() || []);
+
+  return { content, footers };
 });
 
-const footerChildren = computed(() => {
-  const defaultSlot = slots.default?.() || [];
-  return defaultSlot.filter(
-    (vnode: VNode) => getComponentName(vnode) === 'UnnnicPopoverFooter',
-  );
-});
+const contentChildren = computed(() => splitSlot.value.content);
+const footerChildren = computed(() => splitSlot.value.footers);
 
 const contentWidth = computed(() => {
   if (props.width) return props.width;

--- a/src/components/ui/popover/PopoverFooter.vue
+++ b/src/components/ui/popover/PopoverFooter.vue
@@ -1,13 +1,32 @@
 <template>
-  <footer class="unnnic-popover__footer">
+  <Teleport
+    v-if="target"
+    :to="target"
+  >
+    <footer class="unnnic-popover__footer">
+      <slot />
+    </footer>
+  </Teleport>
+
+  <footer
+    v-else
+    class="unnnic-popover__footer"
+  >
     <slot />
   </footer>
 </template>
 
 <script setup lang="ts">
+import { inject } from 'vue';
+import { POPOVER_FOOTER_TARGET } from './context';
+
 defineOptions({
   name: 'UnnnicPopoverFooter',
 });
+
+// When rendered inside a PopoverContent, teleport into its footer container.
+// Falls back to inline rendering when used standalone (no target provided).
+const target = inject(POPOVER_FOOTER_TARGET, null);
 </script>
 
 <style lang="scss">

--- a/src/components/ui/popover/PopoverFooter.vue
+++ b/src/components/ui/popover/PopoverFooter.vue
@@ -21,12 +21,8 @@ $popover-space: $unnnic-space-4;
   padding: $popover-space;
 
   display: flex;
-  justify-content: center;
+  justify-content: flex-end;
   align-items: center;
   gap: $unnnic-space-2;
-
-  > * {
-    width: 100%;
-  }
 }
 </style>

--- a/src/components/ui/popover/__tests__/PopoverFooter.spec.js
+++ b/src/components/ui/popover/__tests__/PopoverFooter.spec.js
@@ -1,0 +1,116 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import PopoverContent from '../PopoverContent.vue';
+import PopoverFooter from '../PopoverFooter.vue';
+
+// Render reka-ui's portal/content inline so the component's own markup
+// (`.unnnic-popover__content` + footer container) is testable. The native
+// Teleport is kept real so we can assert the footer actually moves.
+const inlineSlot = { template: '<div><slot /></div>' };
+
+const globalStubs = {
+  PopoverPortal: inlineSlot,
+  PopoverContent: inlineSlot,
+};
+
+// A child component that renders the footer from its own template, simulating
+// a footer nested inside a consumer component rather than a direct slot child.
+const NestedFooterChild = {
+  components: { PopoverFooter },
+  template: `
+    <section data-testid="nested-wrapper">
+      <PopoverFooter>
+        <button data-testid="nested-footer-btn">Save</button>
+      </PopoverFooter>
+    </section>
+  `,
+};
+
+const mountPopover = (defaultSlot) =>
+  mount(PopoverContent, {
+    attachTo: document.body,
+    slots: { default: defaultSlot },
+    global: {
+      stubs: globalStubs,
+      components: { PopoverFooter, NestedFooterChild },
+    },
+  });
+
+const content = (wrapper) => wrapper.find('.unnnic-popover__content');
+const footerContainer = (wrapper) =>
+  wrapper.find('[data-testid="popover-footer-container"]');
+
+describe('UnnnicPopoverFooter', () => {
+  it('renders a direct footer child inside the footer container, outside the content', async () => {
+    const wrapper = mountPopover(
+      `<p data-testid="body">Body</p>
+       <PopoverFooter><button data-testid="footer-btn">Save</button></PopoverFooter>`,
+    );
+    await flushPromises();
+
+    expect(
+      footerContainer(wrapper).find('.unnnic-popover__footer').exists(),
+    ).toBe(true);
+    expect(content(wrapper).find('.unnnic-popover__footer').exists()).toBe(
+      false,
+    );
+    expect(wrapper.find('[data-testid="footer-btn"]').exists()).toBe(true);
+
+    wrapper.unmount();
+  });
+
+  it('renders a footer nested inside a child component in the footer container', async () => {
+    const wrapper = mountPopover('<NestedFooterChild />');
+    await flushPromises();
+
+    expect(
+      footerContainer(wrapper).find('.unnnic-popover__footer').exists(),
+    ).toBe(true);
+    expect(
+      footerContainer(wrapper)
+        .find('[data-testid="nested-footer-btn"]')
+        .exists(),
+    ).toBe(true);
+    expect(content(wrapper).find('.unnnic-popover__footer').exists()).toBe(
+      false,
+    );
+
+    wrapper.unmount();
+  });
+
+  it('renders no footer area when no footer is provided', async () => {
+    const wrapper = mountPopover('<p data-testid="body">Body</p>');
+    await flushPromises();
+
+    expect(wrapper.find('.unnnic-popover__footer').exists()).toBe(false);
+    expect(footerContainer(wrapper).element.children.length).toBe(0);
+
+    wrapper.unmount();
+  });
+
+  it('teleports every footer into the container when multiple are provided', async () => {
+    const wrapper = mountPopover(
+      `<PopoverFooter><span>First</span></PopoverFooter>
+       <PopoverFooter><span>Second</span></PopoverFooter>`,
+    );
+    await flushPromises();
+
+    const footers = footerContainer(wrapper).findAll('.unnnic-popover__footer');
+    expect(footers).toHaveLength(2);
+    expect(content(wrapper).find('.unnnic-popover__footer').exists()).toBe(
+      false,
+    );
+
+    wrapper.unmount();
+  });
+
+  it('renders inline as a fallback when used without a PopoverContent target', () => {
+    const wrapper = mount(PopoverFooter, {
+      slots: { default: '<button data-testid="standalone">Save</button>' },
+    });
+
+    const footer = wrapper.find('.unnnic-popover__footer');
+    expect(footer.exists()).toBe(true);
+    expect(footer.find('[data-testid="standalone"]').exists()).toBe(true);
+  });
+});

--- a/src/components/ui/popover/context.ts
+++ b/src/components/ui/popover/context.ts
@@ -1,0 +1,4 @@
+import type { InjectionKey, Ref } from 'vue';
+
+export const POPOVER_FOOTER_TARGET: InjectionKey<Ref<HTMLElement | null>> =
+  Symbol('unnnicPopoverFooterTarget');

--- a/src/stories/PopoverOption.stories.js
+++ b/src/stories/PopoverOption.stories.js
@@ -1,4 +1,5 @@
 import { PopoverOption } from '../components/ui/popover';
+import UnnnicTag from '../components/Tag/Tag.vue';
 import colorsList from '../utils/colorsList';
 
 export default {
@@ -69,6 +70,58 @@ export const Default = {
       <PopoverOption v-bind="args" focused />
       <PopoverOption v-bind="args" icon="delete" scheme="fg-critical" />
       <PopoverOption v-bind="args" icon="info" />
+    </section>
+    `,
+  }),
+};
+
+export const WithTag = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Uses the default slot to render custom content, such as a label alongside a status tag. The option keeps the `space-between` layout, so the tag stays aligned to the end.',
+      },
+      source: {
+        code: `<UnnnicPopoverOption v-for="option in options" :key="option.value">
+  <span class="popover-option__label">{{ option.label }}</span>
+  <UnnnicTag
+    type="default"
+    size="small"
+    :scheme="statusConfig[option.status].scheme"
+    :text="statusConfig[option.status].text"
+  />
+</UnnnicPopoverOption>`,
+      },
+    },
+  },
+  render: () => ({
+    components: { PopoverOption, UnnnicTag },
+    data() {
+      return {
+        options: [
+          { label: 'John Doe', value: 'john-doe', status: 'online' },
+          { label: 'Jane Doe', value: 'jane-doe', status: 'lunch' },
+          { label: 'James Smith', value: 'james-smith', status: 'offline' },
+        ],
+        statusConfig: {
+          online: { scheme: 'green', text: 'Online' },
+          lunch: { scheme: 'orange', text: 'Lunch' },
+          offline: { scheme: 'gray', text: 'Offline' },
+        },
+      };
+    },
+    template: `
+    <section style="display: flex; flex-direction: column; gap: 8px; width: 280px;">
+      <PopoverOption v-for="option in options" :key="option.value" :label="option.label">
+        <span style="flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">{{ option.label }}</span>
+        <unnnic-tag
+          type="default"
+          size="small"
+          :scheme="statusConfig[option.status].scheme"
+          :text="statusConfig[option.status].text"
+        />
+      </PopoverOption>
     </section>
     `,
   }),


### PR DESCRIPTION
## Description

### Type of Change

```
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Tests
- [ ] Other
```

### Motivation and Context

`UnnnicPopoverFooter` was only detected when placed as a direct top-level child of the popover's default slot. If the footer was wrapped inside any container element (e.g. `<section>`) or rendered from within a child component, it was rendered inside `unnnic-popover__content` instead of the dedicated footer area, breaking the expected layout.

### Summary of Changes

- `PopoverContent` now provides a `ref` target via Vue's `provide`/`inject` mechanism (using a typed `InjectionKey` defined in a new `context.ts` file). Instead of inspecting vnodes to split slot children, it exposes a DOM ref that `PopoverFooter` can teleport into.
- `PopoverFooter` now uses `<Teleport>` to move itself into the footer container provided by `PopoverContent`, regardless of how deeply it is nested. When used standalone (no target injected), it falls back to inline rendering.
- Footer items are now right-aligned (`justify-content: flex-end`) instead of centered, and child elements no longer have `width: 100%` forced on them, allowing buttons and other content to size naturally.
- Tests have been added for `PopoverFooter` covering direct footer children, footers nested inside child components, no-footer cases, multiple footers, and standalone usage.
- `PopoverOption` Storybook now includes a `WithTag` story demonstrating how to use the default slot to render custom content such as a label alongside a status tag.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/cadb8688-e20e-4790-bf11-8a9fdb73bfc1.png)