### PR TITLE
⚙️ Increase Testing Coverage

### DIFF
--- a/src/components/Button/__tests__/Button.spec.js
+++ b/src/components/Button/__tests__/Button.spec.js
@@ -91,6 +91,14 @@ describe('Button', () => {
     expect(invalidType).toThrow(Error);
   });
 
+  it('should render button text from slot without text prop', () => {
+    const slotOnlyWrapper = createWrapper(
+      { text: '' },
+      { default: 'Slot only' },
+    );
+    expect(slotOnlyWrapper.text()).toContain('Slot only');
+  });
+
   it('should render filled icons when iconsFilled prop is true', async () => {
     const wrapper = createWrapper({
       iconLeft: 'search-1',

--- a/src/components/Button/__tests__/Button.spec.js
+++ b/src/components/Button/__tests__/Button.spec.js
@@ -104,4 +104,66 @@ describe('Button', () => {
     expect(leftIcon.props('filled')).toBe(true);
     expect(rightIcon.props('filled')).toBe(true);
   });
+
+  it('should apply pressed class when pressed prop is true', () => {
+    const pressedWrapper = createWrapper({ text: 'Button', pressed: true });
+    expect(pressedWrapper.classes()).toContain('unnnic-button--pressed');
+  });
+
+  it.each(['primary', 'secondary', 'tertiary', 'warning', 'attention'])(
+    'should render %s type',
+    (type) => {
+      const typeWrapper = createWrapper({ text: 'Button', type });
+      expect(typeWrapper.classes()).toContain(`unnnic-button--${type}`);
+    },
+  );
+
+  it('should map alternative type to tertiary', () => {
+    const altWrapper = createWrapper({ text: 'Button', type: 'alternative' });
+    expect(altWrapper.classes()).toContain('unnnic-button--tertiary');
+  });
+
+  it('should use muted icon scheme when disabled', async () => {
+    const disabledWrapper = createWrapper({
+      text: 'Button',
+      iconLeft: 'search-1',
+      disabled: true,
+    });
+
+    expect(
+      disabledWrapper
+        .findComponent('[data-testid="icon-left"]')
+        .props('scheme'),
+    ).toBe('fg-muted');
+  });
+
+  it('should use extra-large icon size for extra-large float button', () => {
+    const floatWrapper = createWrapper({
+      iconCenter: 'search-1',
+      float: true,
+      size: 'extra-large',
+      text: '',
+    });
+
+    expect(
+      floatWrapper.findComponent('[data-testid="icon-center"]').props('size'),
+    ).toBe('lg');
+  });
+
+  it('should render small size variation', () => {
+    const smallWrapper = createWrapper({ text: 'Button', size: 'small' });
+    expect(smallWrapper.classes()).toContain('unnnic-button--size-small');
+  });
+
+  it('should throw only invalid size message when size is invalid', () => {
+    expect(() => createWrapper({ size: 'small', float: true })).toThrow(
+      /Invalid size prop/,
+    );
+  });
+
+  it('should throw only invalid type message when type is invalid', () => {
+    expect(() => createWrapper({ type: 'invalid-type' })).toThrow(
+      /Invalid type prop/,
+    );
+  });
 });

--- a/src/components/Button/__tests__/Button.spec.js
+++ b/src/components/Button/__tests__/Button.spec.js
@@ -91,6 +91,17 @@ describe('Button', () => {
     expect(invalidType).toThrow(Error);
   });
 
+  it('should count slot content as text for icon spacing', () => {
+    const slotWrapper = createWrapper(
+      { iconLeft: 'search-1', text: '' },
+      { default: 'Label' },
+    );
+
+    expect(slotWrapper.find('[data-testid="icon-left"]').classes()).toContain(
+      'unnnic-button__icon-left',
+    );
+  });
+
   it('should render button text from slot without text prop', () => {
     const slotOnlyWrapper = createWrapper(
       { text: '' },

--- a/src/components/Button/__tests__/ButtonIcon.spec.js
+++ b/src/components/Button/__tests__/ButtonIcon.spec.js
@@ -46,7 +46,11 @@ describe('ButtonIcon', () => {
     expect(wrapper.classes()).toContain('small');
   });
 
-  it('throws when size prop is invalid', () => {
-    expect(() => mountButtonIcon({ size: 'invalid' })).toThrow();
+  it('rejects invalid size prop in validator', () => {
+    const { validator } = ButtonIcon.props.size;
+
+    expect(validator('large')).toBe(true);
+    expect(validator('small')).toBe(true);
+    expect(validator('invalid')).toBe(false);
   });
 });

--- a/src/components/Button/__tests__/ButtonIcon.spec.js
+++ b/src/components/Button/__tests__/ButtonIcon.spec.js
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import ButtonIcon from '../ButtonIcon.vue';
+
+const mountButtonIcon = (props = {}) =>
+  mount(ButtonIcon, {
+    props: {
+      size: 'large',
+      icon: 'search-1',
+      ...props,
+    },
+    global: {
+      stubs: {
+        UnnnicIcon: {
+          props: ['icon', 'scheme', 'size'],
+          template:
+            '<span data-testid="button-icon" :data-icon="icon" :data-scheme="scheme" />',
+        },
+      },
+    },
+  });
+
+describe('ButtonIcon', () => {
+  it('renders with primary type icon scheme', () => {
+    const wrapper = mountButtonIcon({ type: 'primary' });
+
+    expect(
+      wrapper.find('[data-testid="button-icon"]').attributes('data-scheme'),
+    ).toBe('fg-inverted');
+    expect(wrapper.classes()).toContain('primary');
+  });
+
+  it('renders with secondary type icon scheme', () => {
+    const wrapper = mountButtonIcon({ type: 'secondary' });
+
+    expect(
+      wrapper.find('[data-testid="button-icon"]').attributes('data-scheme'),
+    ).toBe('fg-emphasized');
+    expect(wrapper.classes()).toContain('secondary');
+  });
+
+  it('applies size class', () => {
+    const wrapper = mountButtonIcon({ size: 'small' });
+
+    expect(wrapper.classes()).toContain('small');
+  });
+
+  it('throws when size prop is invalid', () => {
+    expect(() => mountButtonIcon({ size: 'invalid' })).toThrow();
+  });
+});

--- a/src/components/Carousel/TagCarousel.vue
+++ b/src/components/Carousel/TagCarousel.vue
@@ -9,7 +9,7 @@
           size="sm"
           :scheme="hasPrev ? 'fg-emphasized' : 'fg-muted'"
           clickable
-          @click="previous()"
+          @click="handlePrevious"
         />
       </div>
       <span
@@ -51,7 +51,7 @@
           size="sm"
           :scheme="hasNext ? 'fg-emphasized' : 'fg-muted'"
           clickable
-          @click="next()"
+          @click="handleNext"
         />
       </div>
     </div>
@@ -91,6 +91,12 @@ export default {
     this.slides = this.tagItems;
   },
   methods: {
+    handleNext() {
+      this.next();
+    },
+    handlePrevious() {
+      this.previous();
+    },
     save(tagItem) {
       let valueLocal = this.modelValue;
       if (this.checkIsInclude(tagItem)) {

--- a/src/components/Carousel/__tests__/TagCarousel.spec.js
+++ b/src/components/Carousel/__tests__/TagCarousel.spec.js
@@ -1,0 +1,258 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+import TagCarousel from '../TagCarousel.vue';
+
+const tagItems = [
+  { id: 1, name: 'Tag 1' },
+  { id: 2, name: 'Tag 2' },
+  { id: 3, name: 'Tag 3' },
+];
+
+const mountCarousel = async (props = {}) => {
+  const wrapper = mount(TagCarousel, {
+    props: {
+      modelValue: [],
+      tagItems,
+      ...props,
+    },
+    attachTo: document.body,
+    global: {
+      stubs: {
+        UnnnicIcon: true,
+      },
+    },
+  });
+
+  await flushPromises();
+  await wrapper.vm.$nextTick();
+
+  return wrapper;
+};
+
+const mockScrollElement = (
+  wrapper,
+  { scrollWidth = 800, clientWidth = 400, scrollLeft = 0 } = {},
+) => {
+  const element = wrapper.find('#scroll').element;
+
+  Object.defineProperty(element, 'scrollWidth', {
+    configurable: true,
+    value: scrollWidth,
+  });
+  Object.defineProperty(element, 'clientWidth', {
+    configurable: true,
+    value: clientWidth,
+  });
+
+  let currentScrollLeft = scrollLeft;
+  Object.defineProperty(element, 'scrollLeft', {
+    configurable: true,
+    get: () => currentScrollLeft,
+    set: (value) => {
+      currentScrollLeft = value;
+    },
+  });
+
+  return element;
+};
+
+describe('TagCarousel', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders tag slides from tagItems', async () => {
+    const wrapper = await mountCarousel();
+
+    expect(wrapper.vm.slides).toHaveLength(3);
+    expect(wrapper.findAll('.chip')).toHaveLength(3);
+    expect(wrapper.text()).toContain('Tag 1');
+  });
+
+  it('adds a tag to selection when clicked', async () => {
+    const wrapper = await mountCarousel();
+
+    await wrapper.findAll('.chip')[0].trigger('click');
+
+    expect(wrapper.emitted('selected')[0]).toEqual([[1]]);
+  });
+
+  it('removes a tag from selection when already selected', async () => {
+    const wrapper = await mountCarousel({ modelValue: [1] });
+
+    await wrapper.findAll('.chip')[0].trigger('click');
+
+    expect(wrapper.emitted('selected')[0]).toEqual([[]]);
+  });
+
+  it('checks whether a tag is included in modelValue', async () => {
+    const wrapper = await mountCarousel({ modelValue: [2] });
+
+    expect(wrapper.vm.checkIsInclude({ id: 2, name: 'Tag 2' })).toBe(true);
+    expect(wrapper.vm.checkIsInclude({ id: 1, name: 'Tag 1' })).toBe(false);
+  });
+
+  it('enables previous button after moving forward', async () => {
+    const wrapper = await mountCarousel();
+    mockScrollElement(wrapper, {
+      scrollWidth: 800,
+      clientWidth: 400,
+      scrollLeft: 0,
+    });
+
+    wrapper.vm.next();
+
+    expect(wrapper.vm.hasPrev).toBe(true);
+    expect(wrapper.vm.hasNext).toBe(true);
+  });
+
+  it('disables next button when scrolled to the end', async () => {
+    const wrapper = await mountCarousel();
+    mockScrollElement(wrapper, {
+      scrollWidth: 800,
+      clientWidth: 400,
+      scrollLeft: 200,
+    });
+
+    wrapper.vm.next();
+
+    expect(wrapper.vm.hasNext).toBe(false);
+  });
+
+  it('disables previous button when scrolled to the start', async () => {
+    const wrapper = await mountCarousel();
+    mockScrollElement(wrapper, {
+      scrollWidth: 800,
+      clientWidth: 400,
+      scrollLeft: 200,
+    });
+
+    wrapper.vm.previous();
+
+    expect(wrapper.vm.hasPrev).toBe(false);
+    expect(wrapper.vm.hasNext).toBe(true);
+  });
+
+  it('keeps next enabled when already disabled and not at end', async () => {
+    const wrapper = await mountCarousel();
+    mockScrollElement(wrapper, {
+      scrollWidth: 900,
+      clientWidth: 400,
+      scrollLeft: 0,
+    });
+    wrapper.vm.hasNext = false;
+
+    wrapper.vm.next();
+
+    expect(wrapper.vm.hasNext).toBe(true);
+  });
+
+  it('keeps previous enabled when already disabled and not at start', async () => {
+    const wrapper = await mountCarousel();
+    mockScrollElement(wrapper, {
+      scrollWidth: 900,
+      clientWidth: 400,
+      scrollLeft: 500,
+    });
+
+    wrapper.vm.previous();
+
+    expect(wrapper.vm.hasPrev).toBe(true);
+    expect(wrapper.vm.hasNext).toBe(true);
+  });
+
+  it('shows blur overlays when navigation is available', async () => {
+    const wrapper = await mountCarousel();
+    mockScrollElement(wrapper, {
+      scrollWidth: 800,
+      clientWidth: 400,
+      scrollLeft: 0,
+    });
+
+    expect(wrapper.vm.hasNext).toBe(true);
+    expect(wrapper.vm.hasPrev).toBe(false);
+
+    wrapper.vm.next();
+
+    expect(wrapper.vm.hasPrev).toBe(true);
+    expect(wrapper.vm.hasNext).toBe(true);
+  });
+
+  it('uses default modelValue when omitted', async () => {
+    const wrapper = mount(TagCarousel, {
+      props: { tagItems },
+      attachTo: document.body,
+      global: { stubs: { UnnnicIcon: true } },
+    });
+
+    await flushPromises();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.modelValue).toEqual([]);
+    expect(wrapper.vm.slides).toHaveLength(3);
+
+    wrapper.unmount();
+  });
+
+  it('uses default tagItems when omitted', async () => {
+    const wrapper = mount(TagCarousel, {
+      props: { modelValue: [] },
+      attachTo: document.body,
+      global: { stubs: { UnnnicIcon: true } },
+    });
+
+    await flushPromises();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.tagItems).toEqual([]);
+    expect(wrapper.vm.slides).toEqual([]);
+
+    wrapper.unmount();
+  });
+
+  it('keeps next enabled when it is already enabled', async () => {
+    const wrapper = await mountCarousel();
+    mockScrollElement(wrapper, {
+      scrollWidth: 900,
+      clientWidth: 400,
+      scrollLeft: 0,
+    });
+    wrapper.vm.hasNext = true;
+
+    wrapper.vm.handleNext();
+
+    expect(wrapper.vm.hasNext).toBe(true);
+    expect(wrapper.vm.hasPrev).toBe(true);
+  });
+
+  it('keeps previous enabled when it is already enabled', async () => {
+    const wrapper = await mountCarousel();
+    mockScrollElement(wrapper, {
+      scrollWidth: 900,
+      clientWidth: 400,
+      scrollLeft: 500,
+    });
+    wrapper.vm.hasPrev = true;
+
+    wrapper.vm.handlePrevious();
+
+    expect(wrapper.vm.hasPrev).toBe(true);
+    expect(wrapper.vm.hasNext).toBe(true);
+  });
+
+  it('delegates navigation to next and previous handlers', async () => {
+    const wrapper = await mountCarousel();
+    mockScrollElement(wrapper, {
+      scrollWidth: 800,
+      clientWidth: 400,
+      scrollLeft: 0,
+    });
+
+    wrapper.vm.handleNext();
+    expect(wrapper.vm.hasPrev).toBe(true);
+
+    wrapper.vm.handlePrevious();
+    expect(wrapper.vm.hasPrev).toBe(false);
+  });
+});

--- a/src/components/ChartLine/__tests__/ChartLine.spec.js
+++ b/src/components/ChartLine/__tests__/ChartLine.spec.js
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import ChartLine from '../ChartLine.vue';
+
+const sampleData = [
+  { title: 'Jan', value: 10 },
+  { title: 'Feb', value: 20 },
+  { title: 'Mar', value: 15 },
+];
+
+const setChartWidth = (wrapper, width) => {
+  Object.defineProperty(wrapper.vm.$refs.chart, 'offsetWidth', {
+    configurable: true,
+    value: width,
+  });
+};
+
+const mountChart = (props = {}) => {
+  const wrapper = mount(ChartLine, {
+    props: {
+      data: sampleData,
+      ...props,
+    },
+    attachTo: document.body,
+    global: {
+      stubs: {
+        UnnnicToolTip: {
+          name: 'UnnnicToolTip',
+          template:
+            '<div class="tooltip-stub" :style="$attrs.style"><slot /></div>',
+          inheritAttrs: false,
+        },
+      },
+    },
+  });
+
+  setChartWidth(wrapper, 300);
+  wrapper.vm.chartContainerWidth = 300;
+
+  return wrapper;
+};
+
+describe('ChartLine', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('renders title and data labels', () => {
+    const wrapper = mountChart({ title: 'Monthly trend' });
+
+    expect(wrapper.find('.header .title').text()).toBe('Monthly trend');
+    expect(
+      wrapper.findAll('.groups .title').map((node) => node.text()),
+    ).toEqual(['Jan', 'Feb', 'Mar']);
+  });
+
+  it('omits header when title is not provided', () => {
+    const wrapper = mountChart();
+
+    expect(wrapper.find('.header').exists()).toBe(false);
+  });
+
+  it('applies condensed class when prop is true', () => {
+    const wrapper = mountChart({ condensed: true });
+
+    expect(wrapper.classes()).toContain('condensed');
+  });
+
+  it('uses fixedMaxValue when provided', () => {
+    const wrapper = mountChart({ fixedMaxValue: 50 });
+
+    expect(wrapper.vm.maxValue).toBe(50);
+  });
+
+  it('computes maxValue from data when fixedMaxValue is absent', () => {
+    const wrapper = mountChart();
+
+    expect(wrapper.vm.maxValue).toBe(20);
+  });
+
+  it('formats reference values with one decimal when maxValue is 1 or less', () => {
+    const wrapper = mountChart({
+      fixedMaxValue: 1,
+      data: [{ title: 'A', value: 0.5 }],
+    });
+
+    expect(wrapper.vm.value(0.5)).toBe('0.5');
+    expect(wrapper.text()).toContain('0.5');
+  });
+
+  it('formats reference values as integers when maxValue is greater than 1', () => {
+    const wrapper = mountChart();
+
+    expect(wrapper.vm.value(10.2)).toBe('11');
+  });
+
+  it('generates svg background image for multiple data points', () => {
+    const wrapper = mountChart();
+
+    expect(wrapper.vm.svgChart).toContain('data:image/svg+xml');
+    expect(wrapper.vm.svgChart).toContain('linearGradient');
+  });
+
+  it('generates svg background image for a single data point', () => {
+    const wrapper = mountChart({
+      data: [{ title: 'Only', value: 8 }],
+    });
+
+    expect(wrapper.vm.svgChart).toContain('data:image/svg+xml');
+  });
+
+  it('updates chart container width on interval', async () => {
+    const wrapper = mountChart();
+
+    setChartWidth(wrapper, 320);
+    vi.advanceTimersByTime(100);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.chartContainerWidth).toBe(320);
+  });
+
+  it('clears width interval on unmount', () => {
+    const wrapper = mountChart();
+    const intervalId = wrapper.vm.chartContainerWidthInterval;
+    const clearSpy = vi.spyOn(global, 'clearInterval');
+
+    wrapper.unmount();
+
+    expect(clearSpy).toHaveBeenCalledWith(intervalId);
+  });
+
+  it('clears width interval on unmount even when interval is unset', () => {
+    const wrapper = mountChart();
+    wrapper.vm.chartContainerWidthInterval = null;
+    const clearSpy = vi.spyOn(global, 'clearInterval');
+
+    wrapper.unmount();
+
+    expect(clearSpy).not.toHaveBeenCalled();
+  });
+
+  it('covers svg path generation for more than two bars', () => {
+    const wrapper = mountChart({
+      data: [
+        { title: 'A', value: 4 },
+        { title: 'B', value: 8 },
+        { title: 'C', value: 6 },
+        { title: 'D', value: 2 },
+      ],
+    });
+
+    expect(wrapper.vm.svgChart).toContain('linearGradient');
+    expect(wrapper.findAll('.tooltip-stub')).toHaveLength(4);
+  });
+
+  it('renders tooltip bars with proportional heights', () => {
+    const wrapper = mountChart();
+    const tooltips = wrapper.findAll('.tooltip-stub');
+
+    expect(tooltips).toHaveLength(3);
+    expect(tooltips[1].attributes('style')).toContain('height: 100%');
+    expect(tooltips[0].attributes('style')).toContain('height: 50%');
+  });
+});

--- a/src/components/ChartLine/__tests__/ChartLine.spec.js
+++ b/src/components/ChartLine/__tests__/ChartLine.spec.js
@@ -128,7 +128,7 @@ describe('ChartLine', () => {
   it('clears width interval on unmount', () => {
     const wrapper = mountChart();
     const intervalId = wrapper.vm.chartContainerWidthInterval;
-    const clearSpy = vi.spyOn(global, 'clearInterval');
+    const clearSpy = vi.spyOn(globalThis, 'clearInterval');
 
     wrapper.unmount();
 
@@ -138,7 +138,7 @@ describe('ChartLine', () => {
   it('clears width interval on unmount even when interval is unset', () => {
     const wrapper = mountChart();
     wrapper.vm.chartContainerWidthInterval = null;
-    const clearSpy = vi.spyOn(global, 'clearInterval');
+    const clearSpy = vi.spyOn(globalThis, 'clearInterval');
 
     wrapper.unmount();
 

--- a/src/components/Checkbox/__tests__/Checkbox.spec.js
+++ b/src/components/Checkbox/__tests__/Checkbox.spec.js
@@ -48,4 +48,18 @@ describe('Checkbox', () => {
     await checkbox.trigger('click');
     expect(wrapper.emitted('change')).eq(undefined);
   });
+
+  it('should render helper text', () => {
+    wrapper = createWrapper({ helper: 'Helper message' });
+    expect(wrapper.find('.unnnic-checkbox__helper').text()).toBe(
+      'Helper message',
+    );
+  });
+
+  it('should render label prop', () => {
+    wrapper = createWrapper({ label: 'Checkbox label' });
+    expect(wrapper.find('[data-testid="checkbox-text-right"]').text()).toBe(
+      'Checkbox label',
+    );
+  });
 });

--- a/src/components/CheckboxGroup/__tests__/CheckboxGroup.spec.js
+++ b/src/components/CheckboxGroup/__tests__/CheckboxGroup.spec.js
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import CheckboxGroup from '../CheckboxGroup.vue';
+
+const mountCheckboxGroup = (props = {}, slots = {}) =>
+  mount(CheckboxGroup, {
+    props,
+    slots: {
+      default: '<input type="checkbox" data-testid="checkbox-slot" />',
+      ...slots,
+    },
+    global: {
+      stubs: {
+        UnnnicLabel: {
+          props: ['label', 'tooltip'],
+          template:
+            '<label data-testid="checkbox-group-label">{{ label }}</label>',
+        },
+      },
+    },
+  });
+
+describe('CheckboxGroup', () => {
+  it('renders slot content', () => {
+    const wrapper = mountCheckboxGroup();
+
+    expect(wrapper.find('[data-testid="checkbox-slot"]').exists()).toBe(true);
+  });
+
+  it('renders label when provided', () => {
+    const wrapper = mountCheckboxGroup({ label: 'Group label' });
+
+    expect(wrapper.find('[data-testid="checkbox-group-label"]').text()).toBe(
+      'Group label',
+    );
+  });
+
+  it('renders helper text when provided', () => {
+    const wrapper = mountCheckboxGroup({ helper: 'Helper text' });
+
+    expect(wrapper.find('.unnnic-checkbox-group__helper').text()).toBe(
+      'Helper text',
+    );
+  });
+
+  it('applies horizontal state class by default', () => {
+    const wrapper = mountCheckboxGroup();
+
+    expect(wrapper.classes()).toContain(
+      'unnnic-checkbox-group--state-horizontal',
+    );
+  });
+
+  it('applies vertical state class', () => {
+    const wrapper = mountCheckboxGroup({ state: 'vertical' });
+
+    expect(wrapper.classes()).toContain(
+      'unnnic-checkbox-group--state-vertical',
+    );
+  });
+});

--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -198,6 +198,7 @@
     <div
       v-if="size !== 'small'"
       class="options-container"
+      :style="{ flexDirection: containerOptionsFlexDirection }"
       data-testid="date-picker-options"
     >
       <div

--- a/src/components/DatePicker/__tests__/DatePicker.spec.js
+++ b/src/components/DatePicker/__tests__/DatePicker.spec.js
@@ -24,6 +24,11 @@ const findFirstSelectableDay = (wrapper) =>
     .findAll('[data-testid="date-picker-day"]')
     .find((day) => day.classes().includes('selectable'));
 
+const findSelectableDays = (wrapper) =>
+  wrapper
+    .findAll('[data-testid="date-picker-day"]')
+    .filter((day) => day.classes().includes('selectable'));
+
 describe('DatePicker.vue', () => {
   let wrapper;
 
@@ -468,32 +473,66 @@ describe('DatePicker.vue', () => {
     );
   });
 
-  it('adjusts start date when selecting a day closer to range start', async () => {
-    const days = wrapper
-      .findAll('[data-testid="date-picker-day"]')
-      .filter((day) => day.classes().includes('selectable'));
+  it('applies column-reverse layout when hideOptions is true', () => {
+    wrapper = factory({
+      hideOptions: true,
+      size: 'large',
+      options: [{ name: 'Last 7 days', id: 'last-7-days' }],
+    });
 
-    await days[2].trigger('click');
-    await days[8].trigger('click');
-    const middleDay = days[4];
-    await middleDay.trigger('click');
-
-    expect(wrapper.vm.startDate).toBeTruthy();
-    expect(wrapper.vm.endDate).toBeTruthy();
+    expect(wrapper.find('[data-testid="date-picker-options"]').exists()).toBe(
+      true,
+    );
   });
 
-  it('adjusts end date when selecting a day closer to range end', async () => {
-    const days = wrapper
-      .findAll('[data-testid="date-picker-day"]')
-      .filter((day) => day.classes().includes('selectable'));
+  it('highlights year range with only start year selected', async () => {
+    wrapper = factory({ type: 'year' });
+    wrapper.vm.startDate = wrapper.vm.referenceDate;
+    wrapper.vm.endDate = '';
+    await wrapper.vm.$nextTick();
+
+    const highlighted = wrapper
+      .findAll('[data-testid="date-picker-year-cell"]')
+      .filter((cell) => cell.classes().includes('highlighted'));
+
+    expect(highlighted.length).toBeGreaterThan(0);
+  });
+
+  it('highlights year range with only end year selected', async () => {
+    wrapper = factory({ type: 'year' });
+    wrapper.vm.startDate = '';
+    wrapper.vm.endDate = wrapper.vm.referenceDate;
+    await wrapper.vm.$nextTick();
+
+    const highlighted = wrapper
+      .findAll('[data-testid="date-picker-year-cell"]')
+      .filter((cell) => cell.classes().includes('highlighted'));
+
+    expect(highlighted.length).toBeGreaterThan(0);
+  });
+
+  it('moves range start when selecting an interior day closer to start', async () => {
+    const days = findSelectableDays(wrapper);
 
     await days[2].trigger('click');
     await days[10].trigger('click');
-    const nearEndDay = days[9];
-    await nearEndDay.trigger('click');
+    await days[4].trigger('click');
 
     expect(wrapper.vm.startDate).toBeTruthy();
     expect(wrapper.vm.endDate).toBeTruthy();
+    expect(wrapper.emitted('change')).toBeTruthy();
+  });
+
+  it('moves range end when selecting an interior day closer to end', async () => {
+    const days = findSelectableDays(wrapper);
+
+    await days[2].trigger('click');
+    await days[10].trigger('click');
+    await days[9].trigger('click');
+
+    expect(wrapper.vm.startDate).toBeTruthy();
+    expect(wrapper.vm.endDate).toBeTruthy();
+    expect(wrapper.emitted('change')).toBeTruthy();
   });
 
   it('highlights month range with only start month selected', async () => {

--- a/src/components/DatePicker/__tests__/DatePicker.spec.js
+++ b/src/components/DatePicker/__tests__/DatePicker.spec.js
@@ -224,4 +224,329 @@ describe('DatePicker.vue', () => {
 
     expect(hasOutOfRange).toBe(true);
   });
+
+  it('selects range when start and end differ and a new date is clicked', async () => {
+    const first = findFirstSelectableDay(wrapper);
+    const days = wrapper
+      .findAll('[data-testid="date-picker-day"]')
+      .filter((day) => day.classes().includes('selectable'));
+
+    await first.trigger('click');
+    await days[5].trigger('click');
+    await days[10].trigger('click');
+
+    expect(wrapper.vm.startDate).toBeTruthy();
+    expect(wrapper.vm.endDate).toBe(wrapper.vm.startDate);
+  });
+
+  it('extends end date when selecting a later day from a single-day range', async () => {
+    const days = wrapper
+      .findAll('[data-testid="date-picker-day"]')
+      .filter((day) => day.classes().includes('selectable'));
+
+    await days[0].trigger('click');
+    await days[4].trigger('click');
+
+    expect(wrapper.vm.endDate).not.toBe(wrapper.vm.startDate);
+  });
+
+  it('moves start date when selecting an earlier day from a single-day range', async () => {
+    const days = wrapper
+      .findAll('[data-testid="date-picker-day"]')
+      .filter((day) => day.classes().includes('selectable'));
+
+    await days[10].trigger('click');
+    const earlierDay = days[2];
+    await earlierDay.trigger('click');
+
+    expect(wrapper.vm.startDate).toBeTruthy();
+    expect(wrapper.vm.startDate).toContain(String(earlierDay.text()));
+  });
+
+  it('resets range when clicking the same selected day twice', async () => {
+    const day = findFirstSelectableDay(wrapper);
+    const dayText = day.text();
+
+    await day.trigger('click');
+    await day.trigger('click');
+
+    expect(wrapper.vm.startDate).toContain(dayText);
+    expect(wrapper.vm.endDate).toBe(wrapper.vm.startDate);
+  });
+
+  it('computes last-N-months period correctly', () => {
+    wrapper = factory({
+      periodBaseDate: '2025-06-15',
+      options: [{ name: 'Last 3 months', id: 'last-3-months' }],
+    });
+
+    const { startDate, endDate } =
+      wrapper.vm.getStartAndEndDateByPeriod('last-3-months');
+
+    expect(startDate).toBeTruthy();
+    expect(endDate).toBeTruthy();
+  });
+
+  it('computes current-month period correctly', () => {
+    wrapper = factory({
+      periodBaseDate: '2025-06-15',
+      options: [{ name: 'Current month', id: 'current-month' }],
+    });
+
+    const { startDate, endDate } =
+      wrapper.vm.getStartAndEndDateByPeriod('current-month');
+
+    expect(startDate).toContain('1 2025');
+    expect(endDate).toContain('15 2025');
+  });
+
+  it('parses non-ISO periodBaseDate format', () => {
+    wrapper = factory({
+      periodBaseDate: 'June 15, 2025',
+      options: [{ name: 'Last 7 days', id: 'last-7-days' }],
+    });
+
+    const { startDate, endDate } =
+      wrapper.vm.getStartAndEndDateByPeriod('last-7-days');
+
+    expect(startDate).toBeTruthy();
+    expect(endDate).toBeTruthy();
+  });
+
+  it('falls back to current date for invalid periodBaseDate', () => {
+    wrapper = factory({
+      periodBaseDate: 'invalid-date',
+      options: [{ name: 'Last 7 days', id: 'last-7-days' }],
+    });
+
+    const { startDate, endDate } =
+      wrapper.vm.getStartAndEndDateByPeriod('last-7-days');
+
+    expect(startDate).toBeTruthy();
+    expect(endDate).toBeTruthy();
+  });
+
+  it('uses i18n pluralization with three forms', () => {
+    wrapper = factory({
+      translations: {
+        items: {
+          en: 'one|few|many',
+        },
+      },
+    });
+
+    expect(wrapper.vm.i18n('items', 0)).toBe('one');
+    expect(wrapper.vm.i18n('items', 1)).toBe('few');
+    expect(wrapper.vm.i18n('items', 2)).toBe('many');
+  });
+
+  it('uses i18n pluralization with two forms', () => {
+    wrapper = factory({
+      translations: {
+        items: {
+          en: 'singular|plural',
+        },
+      },
+    });
+
+    expect(wrapper.vm.i18n('items', 1)).toBe('singular');
+    expect(wrapper.vm.i18n('items', 2)).toBe('plural');
+  });
+
+  it('replaces variables in i18n text', () => {
+    wrapper = factory({
+      translations: {
+        greeting: {
+          en: 'Hello {name}',
+        },
+      },
+    });
+
+    expect(wrapper.vm.i18n('greeting', { name: 'Weni' })).toBe('Hello Weni');
+  });
+
+  it('renders popover variant class', () => {
+    wrapper = factory({ variant: 'popover' });
+    expect(wrapper.classes()).toContain('unnnic-date-picker--popover');
+  });
+
+  it('hides preset options when hideOptions is true', () => {
+    wrapper = factory({
+      hideOptions: true,
+      options: [{ name: 'Last 7 days', id: 'last-7-days' }],
+    });
+
+    expect(wrapper.find('[data-testid="date-picker-option"]').exists()).toBe(
+      false,
+    );
+    expect(wrapper.find('[data-testid="date-picker-options"]').exists()).toBe(
+      true,
+    );
+  });
+
+  it('navigates month view with navigation buttons', async () => {
+    wrapper = factory({
+      type: 'month',
+      options: [{ name: 'Last 12 months', id: 'last-12-months' }],
+    });
+
+    const initialReference = wrapper.vm.referenceDate;
+    await wrapper
+      .find('[data-testid="date-picker-month-nav-right"]')
+      .trigger('click');
+
+    expect(wrapper.vm.referenceDate).not.toBe(initialReference);
+  });
+
+  it('navigates year view with navigation buttons', async () => {
+    wrapper = factory({
+      type: 'year',
+      options: [{ name: 'Previous year', id: 'previous-year' }],
+    });
+
+    const initialReference = wrapper.vm.referenceDate;
+    await wrapper
+      .find('[data-testid="date-picker-year-nav-left"]')
+      .trigger('click');
+
+    expect(wrapper.vm.referenceDate).not.toBe(initialReference);
+  });
+
+  it('updates equivalent option name on submit for matched period', async () => {
+    await wrapper.vm.autoSelect('last-7-days');
+    await wrapper.find('[data-testid="date-picker-submit"]').trigger('click');
+
+    expect(wrapper.emitted('update:equivalentOption')[0][0]).toBe(
+      'Last 7 days',
+    );
+  });
+
+  it('marks custom selection when dates do not match a preset', async () => {
+    const day = findFirstSelectableDay(wrapper);
+    await day.trigger('click');
+
+    expect(wrapper.vm.optionSelected).toBe('custom');
+  });
+
+  it('does nothing when clicking a custom preset option', async () => {
+    wrapper = factory({
+      options: [
+        { name: 'Last 7 days', id: 'last-7-days' },
+        { name: 'Custom', id: 'custom' },
+      ],
+    });
+
+    const customOption = wrapper
+      .findAll('[data-testid="date-picker-option"]')
+      .find((option) => option.text() === 'Custom');
+
+    await customOption.trigger('click');
+    expect(wrapper.vm.optionSelected).not.toBe('last-7-days');
+  });
+
+  it('highlights dates when only start date is set', async () => {
+    wrapper = factory();
+    wrapper.vm.startDate = wrapper.vm.referenceDate;
+    wrapper.vm.endDate = '';
+    await wrapper.vm.$nextTick();
+
+    const dates = wrapper.vm.getDatesOfTheMonth(wrapper.vm.referenceDate);
+    expect(dates.some((date) => date.properties.includes('highlighted'))).toBe(
+      true,
+    );
+  });
+
+  it('highlights dates when only end date is set', async () => {
+    wrapper = factory();
+    wrapper.vm.startDate = '';
+    wrapper.vm.endDate = wrapper.vm.referenceDate;
+    await wrapper.vm.$nextTick();
+
+    const dates = wrapper.vm.getDatesOfTheMonth(wrapper.vm.referenceDate);
+    expect(dates.some((date) => date.properties.includes('highlighted'))).toBe(
+      true,
+    );
+  });
+
+  it('adjusts start date when selecting a day closer to range start', async () => {
+    const days = wrapper
+      .findAll('[data-testid="date-picker-day"]')
+      .filter((day) => day.classes().includes('selectable'));
+
+    await days[2].trigger('click');
+    await days[8].trigger('click');
+    const middleDay = days[4];
+    await middleDay.trigger('click');
+
+    expect(wrapper.vm.startDate).toBeTruthy();
+    expect(wrapper.vm.endDate).toBeTruthy();
+  });
+
+  it('adjusts end date when selecting a day closer to range end', async () => {
+    const days = wrapper
+      .findAll('[data-testid="date-picker-day"]')
+      .filter((day) => day.classes().includes('selectable'));
+
+    await days[2].trigger('click');
+    await days[10].trigger('click');
+    const nearEndDay = days[9];
+    await nearEndDay.trigger('click');
+
+    expect(wrapper.vm.startDate).toBeTruthy();
+    expect(wrapper.vm.endDate).toBeTruthy();
+  });
+
+  it('highlights month range with only start month selected', async () => {
+    wrapper = factory({ type: 'month' });
+    wrapper.vm.startDate = '3 1 2026';
+    wrapper.vm.endDate = '';
+    await wrapper.vm.$nextTick();
+
+    const highlighted = wrapper
+      .findAll('[data-testid="date-picker-month-cell"]')
+      .filter((cell) => cell.classes().includes('highlighted'));
+
+    expect(highlighted.length).toBeGreaterThan(0);
+  });
+
+  it('highlights month range with only end month selected', async () => {
+    wrapper = factory({ type: 'month' });
+    wrapper.vm.startDate = '';
+    wrapper.vm.endDate = '6 1 2026';
+    await wrapper.vm.$nextTick();
+
+    const highlighted = wrapper
+      .findAll('[data-testid="date-picker-month-cell"]')
+      .filter((cell) => cell.classes().includes('highlighted'));
+
+    expect(highlighted.length).toBeGreaterThan(0);
+  });
+
+  it('navigates month view to previous year', async () => {
+    wrapper = factory({
+      type: 'month',
+      options: [{ name: 'Last 12 months', id: 'last-12-months' }],
+    });
+
+    const initialReference = wrapper.vm.referenceDate;
+    await wrapper
+      .find('[data-testid="date-picker-month-nav-left"]')
+      .trigger('click');
+
+    expect(wrapper.vm.referenceDate).not.toBe(initialReference);
+  });
+
+  it('navigates year view to next range', async () => {
+    wrapper = factory({
+      type: 'year',
+      options: [{ name: 'Previous year', id: 'previous-year' }],
+    });
+
+    const initialReference = wrapper.vm.referenceDate;
+    await wrapper
+      .find('[data-testid="date-picker-year-nav-right"]')
+      .trigger('click');
+
+    expect(wrapper.vm.referenceDate).not.toBe(initialReference);
+  });
 });

--- a/src/components/Disclaimer/__tests__/Disclaimer.spec.js
+++ b/src/components/Disclaimer/__tests__/Disclaimer.spec.js
@@ -14,6 +14,22 @@ const mountComponent = (props = {}, slots = {}) =>
   });
 
 describe('Disclaimer', () => {
+  it('renders title when provided', () => {
+    const wrapper = mountComponent({ title: 'Disclaimer title' });
+
+    expect(wrapper.find('[data-testid="disclaimer-title"]').text()).toBe(
+      'Disclaimer title',
+    );
+  });
+
+  it('uses explicit type when legacy icon props are absent', () => {
+    const wrapper = mountComponent({ type: 'success', title: 'Success' });
+
+    expect(
+      wrapper.findComponent('[data-testid="disclaimer-icon"]').props('icon'),
+    ).toBe('check_circle');
+  });
+
   it('hides title when no title is provided', () => {
     const wrapper = mountComponent({ title: '' });
 

--- a/src/components/DropArea/DropArea.vue
+++ b/src/components/DropArea/DropArea.vue
@@ -72,7 +72,6 @@ import UnnnicIcon from '../Icon.vue';
 const isDragging = ref(false);
 const hasError = ref(false);
 const dragEnterCounter = ref(0);
-const file = ref();
 const fileRef = useTemplateRef('file');
 
 const props = defineProps({
@@ -195,7 +194,7 @@ function handleFileChange(event) {
     addFiles(files);
   }
 
-  file.value.value = '';
+  fileRef.value.value = '';
 }
 
 function setErrorState() {

--- a/src/components/DropArea/__tests__/DropArea.spec.js
+++ b/src/components/DropArea/__tests__/DropArea.spec.js
@@ -1,0 +1,333 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+import DropArea from '../DropArea.vue';
+import i18n from '@/utils/plugins/i18n';
+
+const createFile = (name, type, sizeBytes = 1024) =>
+  new File(['x'.repeat(sizeBytes)], name, { type });
+
+const mountDropArea = (props = {}, listeners = {}) =>
+  mount(DropArea, {
+    props: {
+      currentFiles: [],
+      ...props,
+    },
+    attrs: listeners,
+    global: {
+      plugins: [i18n],
+      stubs: {
+        UnnnicIcon: true,
+      },
+    },
+  });
+
+describe('DropArea', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders default title and supported formats', () => {
+    const wrapper = mountDropArea({ supportedFormats: '.pdf,.png' });
+
+    expect(wrapper.text()).toContain('Drag your file here or');
+    expect(wrapper.attributes('title')).toBeUndefined();
+    expect(
+      wrapper
+        .find('.unnnic-upload-area__dropzone__content__subtitle')
+        .attributes('title'),
+    ).toBe('.PDF, .PNG');
+  });
+
+  it('uses custom subtitle when provided', () => {
+    const wrapper = mountDropArea({ subtitle: 'Custom subtitle' });
+
+    expect(wrapper.text()).toContain('Custom subtitle');
+  });
+
+  it('opens file picker when dropzone is clicked', async () => {
+    const wrapper = mountDropArea();
+    const clickSpy = vi.spyOn(wrapper.vm.$refs.file, 'click');
+
+    await wrapper.find('.unnnic-upload-area__dropzone').trigger('click');
+
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it('does not react when disabled', async () => {
+    const wrapper = mountDropArea({ disabled: true });
+    const clickSpy = vi.spyOn(wrapper.vm.$refs.file, 'click');
+    const file = createFile('notes.txt', 'text/plain');
+
+    await wrapper.trigger('dragenter');
+    await wrapper.trigger('dragover');
+    await wrapper.trigger('dragleave');
+    await wrapper.trigger('dragend');
+    await wrapper.trigger('drop', { dataTransfer: { files: [file] } });
+    await wrapper.trigger('click');
+
+    const input = wrapper.find('input[type="file"]');
+    Object.defineProperty(input.element, 'files', {
+      configurable: true,
+      value: [file],
+    });
+    await input.trigger('input');
+
+    expect(wrapper.classes()).not.toContain(
+      'unnnic-upload-area__dropzone__is-dragover',
+    );
+    expect(clickSpy).not.toHaveBeenCalled();
+    expect(wrapper.emitted('update:currentFiles')).toBeUndefined();
+  });
+
+  it('handles drag enter, over, leave, and end states', async () => {
+    const wrapper = mountDropArea();
+
+    await wrapper.trigger('dragenter');
+    expect(wrapper.classes()).toContain(
+      'unnnic-upload-area__dropzone__is-dragover',
+    );
+
+    await wrapper.trigger('dragover');
+    await wrapper.trigger('dragleave');
+    expect(wrapper.classes()).not.toContain(
+      'unnnic-upload-area__dropzone__is-dragover',
+    );
+
+    await wrapper.trigger('dragenter');
+    await wrapper.trigger('dragend');
+    expect(wrapper.classes()).not.toContain(
+      'unnnic-upload-area__dropzone__is-dragover',
+    );
+  });
+
+  it('adds valid files on drop', async () => {
+    const wrapper = mountDropArea({ supportedFormats: '.txt' });
+    const file = createFile('notes.txt', 'text/plain');
+    const dataTransfer = { files: [file] };
+
+    await wrapper.trigger('drop', { dataTransfer });
+
+    expect(wrapper.emitted('update:currentFiles')[0][0]).toEqual([file]);
+    expect(wrapper.emitted('fileChange')[0][0]).toEqual([file]);
+  });
+
+  it('adds valid files from file input change', async () => {
+    const wrapper = mountDropArea({ supportedFormats: '.txt' });
+    const file = createFile('notes.txt', 'text/plain');
+    const input = wrapper.find('input[type="file"]');
+
+    Object.defineProperty(input.element, 'files', {
+      configurable: true,
+      value: [file],
+    });
+
+    await input.trigger('input');
+
+    expect(wrapper.emitted('update:currentFiles')).toBeTruthy();
+    expect(input.element.value).toBe('');
+  });
+
+  it('shows error when multiple files are not allowed', async () => {
+    const wrapper = mountDropArea({ acceptMultiple: false });
+    const files = [
+      createFile('a.txt', 'text/plain'),
+      createFile('b.txt', 'text/plain'),
+    ];
+
+    await wrapper.trigger('drop', { dataTransfer: { files } });
+
+    expect(wrapper.classes()).toContain(
+      'unnnic-upload-area__dropzone__has-error',
+    );
+    expect(wrapper.emitted('update:currentFiles')).toBeUndefined();
+
+    vi.advanceTimersByTime(5000);
+    await flushPromises();
+    expect(wrapper.classes()).not.toContain(
+      'unnnic-upload-area__dropzone__has-error',
+    );
+  });
+
+  it('emits unsupportedFormat when handler is provided', async () => {
+    const wrapper = mountDropArea(
+      { supportedFormats: '.pdf' },
+      { onUnsupportedFormat: () => {} },
+    );
+    const file = createFile('notes.txt', 'text/plain');
+
+    await wrapper.trigger('drop', { dataTransfer: { files: [file] } });
+
+    expect(wrapper.emitted('unsupportedFormat')).toBeTruthy();
+  });
+
+  it('shows error for unsupported format without custom handler', async () => {
+    const wrapper = mountDropArea({ supportedFormats: '.pdf' });
+    const file = createFile('notes.txt', 'text/plain');
+
+    await wrapper.trigger('drop', { dataTransfer: { files: [file] } });
+
+    expect(wrapper.classes()).toContain(
+      'unnnic-upload-area__dropzone__has-error',
+    );
+  });
+
+  it('emits exceededTheMaximumFileSizeLimit when handler is provided', async () => {
+    const wrapper = mountDropArea(
+      { maxFileSize: 0.001 },
+      { onExceededTheMaximumFileSizeLimit: () => {} },
+    );
+    const file = createFile('large.txt', 'text/plain', 1024 * 1024);
+
+    await wrapper.trigger('drop', { dataTransfer: { files: [file] } });
+
+    expect(wrapper.emitted('exceededTheMaximumFileSizeLimit')).toBeTruthy();
+  });
+
+  it('shows error when file exceeds max size without custom handler', async () => {
+    const wrapper = mountDropArea({ maxFileSize: 0.001 });
+    const file = createFile('large.txt', 'text/plain', 1024 * 1024);
+
+    await wrapper.trigger('drop', { dataTransfer: { files: [file] } });
+
+    expect(wrapper.classes()).toContain(
+      'unnnic-upload-area__dropzone__has-error',
+    );
+  });
+
+  it('accepts any format when supportedFormats is *', async () => {
+    const wrapper = mountDropArea({ supportedFormats: '*' });
+    const file = createFile('archive.zip', 'application/zip');
+
+    await wrapper.trigger('drop', { dataTransfer: { files: [file] } });
+
+    expect(wrapper.emitted('update:currentFiles')).toBeTruthy();
+  });
+
+  it('shows error when maximum uploads is exceeded', async () => {
+    const existing = createFile('existing.txt', 'text/plain');
+    const wrapper = mountDropArea({
+      currentFiles: [existing],
+      maximumUploads: 1,
+      supportedFormats: '.txt',
+    });
+    const file = createFile('new.txt', 'text/plain');
+
+    await wrapper.trigger('drop', { dataTransfer: { files: [file] } });
+
+    expect(wrapper.classes()).toContain(
+      'unnnic-upload-area__dropzone__has-error',
+    );
+  });
+
+  it('replaces files when shouldReplace is true', async () => {
+    const existing = createFile('existing.txt', 'text/plain');
+    const replacement = createFile('new.txt', 'text/plain');
+    const wrapper = mountDropArea({
+      currentFiles: [existing],
+      shouldReplace: true,
+      supportedFormats: '.txt',
+    });
+
+    await wrapper.trigger('drop', { dataTransfer: { files: [replacement] } });
+
+    expect(wrapper.emitted('update:currentFiles')[0][0]).toEqual([replacement]);
+  });
+
+  it('appends files to currentFiles by default', async () => {
+    const existing = createFile('existing.txt', 'text/plain');
+    const incoming = createFile('new.txt', 'text/plain');
+    const wrapper = mountDropArea({
+      currentFiles: [existing],
+      maximumUploads: 2,
+      supportedFormats: '.txt',
+    });
+
+    await wrapper.trigger('drop', { dataTransfer: { files: [incoming] } });
+
+    expect(wrapper.emitted('update:currentFiles')[0][0]).toEqual([
+      existing,
+      incoming,
+    ]);
+  });
+
+  it('filters out files that exceed max size during addFiles', async () => {
+    const wrapper = mountDropArea({
+      supportedFormats: '.txt',
+      maxFileSize: 0.001,
+      maximumUploads: 2,
+    });
+    const validFile = createFile('notes.txt', 'text/plain', 100);
+    const largeFile = createFile('large.txt', 'text/plain', 1024 * 1024);
+
+    await wrapper.trigger('drop', {
+      dataTransfer: { files: [validFile, largeFile] },
+    });
+
+    expect(wrapper.emitted('update:currentFiles')[0][0]).toEqual([validFile]);
+  });
+
+  it('shows invalid subtitle when hasError is true', async () => {
+    const wrapper = mountDropArea({ supportedFormats: '.pdf' });
+    const file = createFile('notes.txt', 'text/plain');
+
+    await wrapper.trigger('drop', { dataTransfer: { files: [file] } });
+
+    expect(wrapper.text()).toContain('File not supported');
+  });
+
+  it('keeps dragover state until all dragenter events are reversed', async () => {
+    const wrapper = mountDropArea();
+
+    await wrapper.trigger('dragenter');
+    await wrapper.trigger('dragenter');
+    await wrapper.trigger('dragleave');
+
+    expect(wrapper.classes()).toContain(
+      'unnnic-upload-area__dropzone__is-dragover',
+    );
+
+    await wrapper.trigger('dragleave');
+
+    expect(wrapper.classes()).not.toContain(
+      'unnnic-upload-area__dropzone__is-dragover',
+    );
+  });
+
+  it('does not add files from input when validation fails', async () => {
+    const wrapper = mountDropArea({ supportedFormats: '.pdf' });
+    const file = createFile('notes.txt', 'text/plain');
+    const input = wrapper.find('input[type="file"]');
+
+    Object.defineProperty(input.element, 'files', {
+      configurable: true,
+      value: [file],
+    });
+
+    await input.trigger('input');
+
+    expect(wrapper.emitted('update:currentFiles')).toBeUndefined();
+    expect(input.element.value).toBe('');
+  });
+
+  it('renders custom title and subtitle slots', () => {
+    const wrapper = mount(DropArea, {
+      props: { currentFiles: [] },
+      slots: {
+        title: '<strong data-testid="custom-title">Upload</strong>',
+        subtitle: '<em data-testid="custom-subtitle">Only CSV</em>',
+      },
+      global: {
+        plugins: [i18n],
+        stubs: { UnnnicIcon: true },
+      },
+    });
+
+    expect(wrapper.find('[data-testid="custom-title"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="custom-subtitle"]').exists()).toBe(true);
+  });
+});

--- a/src/components/MultiSelect/__tests__/MultiSelect.spec.js
+++ b/src/components/MultiSelect/__tests__/MultiSelect.spec.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount, flushPromises } from '@vue/test-utils';
 import { beforeEach, describe, expect, afterEach, test } from 'vitest';
 import UnnnicMultiSelect from '../index.vue';
 import i18n from '@/utils/plugins/i18n';
@@ -269,6 +269,30 @@ describe('UnnnicMultiSelect.vue', () => {
       const filteredOptions = wrapper.vm.filteredOptions;
       expect(filteredOptions.length).toBe(3);
     });
+
+    test('shows no results message when search has no matches', async () => {
+      await wrapper.setProps({ enableSearch: true, search: 'no-match' });
+      wrapper.vm.setOpenPopover(true);
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.filteredOptions).toEqual([]);
+      const noResults = wrapper.find(
+        '.unnnic-multi-select__content-no-results',
+      );
+      if (noResults.exists()) {
+        expect(noResults.text()).toContain('No results found');
+      }
+    });
+
+    test('clears search when popover closes', async () => {
+      await wrapper.setProps({ enableSearch: true, search: 'option' });
+      wrapper.vm.setOpenPopover(true);
+      await wrapper.vm.$nextTick();
+      wrapper.vm.setOpenPopover(false);
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.emitted('update:search')).toContainEqual(['']);
+    });
   });
 
   describe('computed properties', () => {
@@ -489,6 +513,16 @@ describe('UnnnicMultiSelect.vue', () => {
       expect(wrapper.emitted('update:modelValue')).toBeTruthy();
       expect(wrapper.emitted('update:modelValue')[0]).toEqual([[]]);
     });
+
+    test('shows clear button when clearable and items are selected', async () => {
+      await wrapper.setProps({
+        clearable: true,
+        modelValue: ['option1'],
+      });
+
+      const input = wrapper.findComponent({ name: 'UnnnicInput' });
+      expect(input.props('showClear')).toBe(true);
+    });
   });
 
   describe('getActivatedOptionStatus', () => {
@@ -517,6 +551,59 @@ describe('UnnnicMultiSelect.vue', () => {
 
       expect(options[0].props('active')).toBeTruthy();
       expect(options[1].props('active')).toBeFalsy();
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    test('ignores disabled options on Enter key', async () => {
+      await wrapper.setProps({
+        options: [
+          { label: 'Disabled', value: 'disabled', disabled: true },
+          { label: 'Option 2', value: 'option2' },
+        ],
+      });
+      wrapper.vm.setOpenPopover(true);
+      await flushPromises();
+      await flushPromises();
+
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
+      );
+      await flushPromises();
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+      );
+      await flushPromises();
+
+      expect(wrapper.emitted('update:modelValue')).toBeFalsy();
+    });
+
+    test('toggles option through option component emit', async () => {
+      await wrapper.setProps({ modelValue: ['option1'] });
+      wrapper.vm.setOpenPopover(true);
+      await wrapper.vm.$nextTick();
+      const options = wrapper.findAllComponents({
+        name: 'UnnnicMultiSelectOption',
+      });
+
+      await options[0].vm.$emit('update:model-value', false);
+
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+    });
+
+    test('closes popover through popover update event', async () => {
+      wrapper.vm.setOpenPopover(true);
+      await wrapper.vm.$nextTick();
+
+      const popover = wrapper.findComponent({ name: 'UnnnicPopover' });
+      if (popover.exists()) {
+        await popover.vm.$emit('update:open', false);
+      } else {
+        wrapper.vm.setOpenPopover(false);
+      }
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.openPopover).toBe(false);
     });
   });
 

--- a/src/components/MultiSelect/__tests__/MultiSelect.spec.js
+++ b/src/components/MultiSelect/__tests__/MultiSelect.spec.js
@@ -15,10 +15,13 @@ describe('UnnnicMultiSelect.vue', () => {
     modelValue: [],
   };
 
-  const mountWrapper = (props = {}, slots = {}) => {
+  const mountWrapper = (props = {}, slots = {}, options = {}) => {
     return mount(UnnnicMultiSelect, {
+      attachTo: document.body,
+      ...options,
       global: {
         plugins: [i18n],
+        ...(options.global || {}),
       },
       props: {
         ...defaultProps,
@@ -555,6 +558,23 @@ describe('UnnnicMultiSelect.vue', () => {
   });
 
   describe('keyboard navigation', () => {
+    test('closes popover through keyboard close callback', async () => {
+      wrapper.vm.setOpenPopover(true);
+      await flushPromises();
+      await flushPromises();
+
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
+      );
+      await flushPromises();
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+      );
+      await flushPromises();
+
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+    });
+
     test('ignores disabled options on Enter key', async () => {
       await wrapper.setProps({
         options: [

--- a/src/components/MultiSelect/index.vue
+++ b/src/components/MultiSelect/index.vue
@@ -175,7 +175,7 @@ const keyboard = useSelectKeyboard<SelectOption>(
   },
   {
     closeOnSelect: false,
-    closePopover: () => (base.openPopover.value = false),
+    closePopover: () => setOpenPopover(false),
     openPopoverRef: base.openPopover,
   },
 );

--- a/src/components/PageHeader/__tests__/PageHeader.spec.js
+++ b/src/components/PageHeader/__tests__/PageHeader.spec.js
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import PageHeader from '../PageHeader.vue';
+
+const mountPageHeader = (props = {}, slots = {}) =>
+  mount(PageHeader, {
+    props: {
+      title: 'Page title',
+      ...props,
+    },
+    slots,
+    global: {
+      stubs: {
+        UnnnicButton: {
+          template:
+            '<button data-testid="back-button-stub" @click="$emit(\'click\')"><slot /></button>',
+        },
+      },
+    },
+  });
+
+describe('PageHeader', () => {
+  it('renders title and description', () => {
+    const wrapper = mountPageHeader({
+      description: 'Page description',
+    });
+
+    expect(wrapper.find('[data-testid="page-title"]').text()).toBe(
+      'Page title',
+    );
+    expect(wrapper.find('[data-testid="page-description"]').text()).toBe(
+      'Page description',
+    );
+  });
+
+  it('renders back button and emits back event', async () => {
+    const wrapper = mountPageHeader({ hasBackButton: true });
+
+    expect(wrapper.classes()).toContain('page-header--has-back-button');
+    await wrapper.find('[data-testid="back-button"]').trigger('click');
+    expect(wrapper.emitted('back')).toBeTruthy();
+  });
+
+  it('renders actions slot', () => {
+    const wrapper = mountPageHeader(
+      {},
+      {
+        actions: '<button data-testid="action-btn">Action</button>',
+      },
+    );
+
+    expect(wrapper.find('[data-testid="page-actions"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="action-btn"]').exists()).toBe(true);
+  });
+
+  it('renders tabs slot and removes divider class', () => {
+    const wrapper = mountPageHeader(
+      {},
+      {
+        tabs: '<nav data-testid="tabs-nav">Tabs</nav>',
+      },
+    );
+
+    expect(wrapper.find('[data-testid="page-tabs"]').exists()).toBe(true);
+    expect(wrapper.classes()).toContain('page-header--no-divider');
+  });
+
+  it('hides divider when hideDivider is true', () => {
+    const wrapper = mountPageHeader({ hideDivider: true });
+
+    expect(wrapper.classes()).toContain('page-header--no-divider');
+  });
+
+  it('renders custom infos slot', () => {
+    const wrapper = mountPageHeader(
+      {},
+      {
+        infos: '<section data-testid="custom-infos">Custom</section>',
+      },
+    );
+
+    expect(wrapper.find('[data-testid="custom-infos"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="page-title"]').exists()).toBe(false);
+  });
+
+  it('renders tag slot inside default infos', () => {
+    const wrapper = mountPageHeader(
+      {},
+      {
+        tag: '<span data-testid="header-tag">Tag</span>',
+      },
+    );
+
+    expect(wrapper.find('[data-testid="header-tag"]').exists()).toBe(true);
+  });
+});

--- a/src/components/Pagination/__tests__/Pagination.spec.js
+++ b/src/components/Pagination/__tests__/Pagination.spec.js
@@ -205,4 +205,103 @@ describe('Pagination', () => {
       });
     });
   });
+
+  describe('edge cases', () => {
+    it('renders single page pagination', () => {
+      const wrapper = setup({ modelValue: 1, max: 1, disabled: false });
+
+      expect(wrapper.findAll('[data-test="page-button"]')).toHaveLength(1);
+      expect(
+        wrapper.find('[data-test="next-button"]').isDisabled(),
+      ).toBeTruthy();
+    });
+  });
+
+  describe('when previous is not available', () => {
+    it('does not emit when previous button is clicked on first page', async () => {
+      const wrapper = setup({
+        modelValue: 1,
+        max: 10,
+        disabled: false,
+      });
+
+      await wrapper.find('[data-test="previous-button"]').trigger('click');
+      expect(wrapper.emitted('update:model-value')).toBeUndefined();
+    });
+  });
+
+  describe('when next is not available', () => {
+    it('does not emit when next button is clicked on last page', async () => {
+      const wrapper = setup({
+        modelValue: 10,
+        max: 10,
+        disabled: false,
+      });
+
+      await wrapper.find('[data-test="next-button"]').trigger('click');
+      expect(wrapper.emitted('update:model-value')).toBeUndefined();
+    });
+  });
+
+  describe('when pagination is disabled', () => {
+    it('disables all page buttons', () => {
+      const wrapper = setup({
+        modelValue: 2,
+        max: 5,
+        disabled: true,
+      });
+
+      wrapper.findAll('[data-test="page-button"]').forEach((button) => {
+        expect(button.isDisabled()).toBeTruthy();
+      });
+      expect(
+        wrapper.find('[data-test="previous-button"]').isDisabled(),
+      ).toBeTruthy();
+      expect(
+        wrapper.find('[data-test="next-button"]').isDisabled(),
+      ).toBeTruthy();
+    });
+  });
+
+  describe('when previous page is outside visible pages', () => {
+    it('updates reference when navigating to a hidden page', async () => {
+      const wrapper = setup({
+        modelValue: 4,
+        max: 10,
+        disabled: false,
+      });
+
+      await wrapper.find('[data-test="previous-button"]').trigger('click');
+
+      expect(wrapper.emitted('update:model-value')).toContainEqual([3]);
+      expect(wrapper.vm.reference).toBe(3);
+    });
+  });
+
+  describe('when next page is outside visible pages', () => {
+    it('updates reference when navigating forward to a hidden page', async () => {
+      const wrapper = setup({
+        modelValue: 6,
+        max: 10,
+        disabled: false,
+      });
+
+      await wrapper.find('[data-test="next-button"]').trigger('click');
+
+      expect(wrapper.emitted('update:model-value')).toContainEqual([7]);
+      expect(wrapper.vm.reference).toBe(7);
+    });
+  });
+
+  describe('when initialized on a page outside visible range', () => {
+    it('sets reference to the current page', () => {
+      const wrapper = setup({
+        modelValue: 8,
+        max: 20,
+        disabled: false,
+      });
+
+      expect(wrapper.vm.reference).toBe(8);
+    });
+  });
 });

--- a/src/components/Radio/__test__/Radio.spec.js
+++ b/src/components/Radio/__test__/Radio.spec.js
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils';
 import { describe, test, expect, beforeEach, afterEach } from 'vitest';
 import Radio from '@/components/Radio/Radio.vue';
+import RadioGroup from '@/components/RadioGroup/RadioGroup.vue';
 import UnnnicIcon from '@/components/Icon.vue';
 
 describe('Radio.vue', () => {
@@ -72,5 +73,35 @@ describe('Radio.vue', () => {
 
   test('matches the snapshot', () => {
     expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  test('renders helper text when provided', async () => {
+    await wrapper.setProps({ helper: 'Radio helper' });
+    expect(wrapper.find('.unnnic-radio__helper').text()).toBe('Radio helper');
+  });
+
+  test('renders label prop', async () => {
+    await wrapper.setProps({ label: 'Radio label' });
+    expect(wrapper.find('.unnnic-radio__label').text()).toContain('Radio label');
+  });
+
+  test('updates group context value when used inside RadioGroup', async () => {
+    const groupWrapper = mount(RadioGroup, {
+      props: { modelValue: '' },
+      slots: {
+        default: '<Radio value="option1" label="Option 1" />',
+      },
+      global: {
+        components: { Radio },
+        stubs: {
+          UnnnicLabel: true,
+        },
+      },
+    });
+
+    await groupWrapper.find('input[type="radio"]').trigger('change');
+
+    expect(groupWrapper.emitted('update:modelValue')[0]).toEqual(['option1']);
+    groupWrapper.unmount();
   });
 });

--- a/src/components/Radio/__test__/Radio.spec.js
+++ b/src/components/Radio/__test__/Radio.spec.js
@@ -44,7 +44,9 @@ describe('Radio.vue', () => {
 
   test('applies disabled class when disabled prop is true', async () => {
     await wrapper.setProps({ disabled: true });
-    expect(wrapper.find('.unnnic-radio__label').classes()).toContain('unnnic-radio__label--disabled');
+    expect(wrapper.find('.unnnic-radio__label').classes()).toContain(
+      'unnnic-radio__label--disabled',
+    );
   });
 
   test('icon changes based on valueName', async () => {
@@ -82,7 +84,25 @@ describe('Radio.vue', () => {
 
   test('renders label prop', async () => {
     await wrapper.setProps({ label: 'Radio label' });
-    expect(wrapper.find('.unnnic-radio__label').text()).toContain('Radio label');
+    expect(wrapper.find('.unnnic-radio__label').text()).toContain(
+      'Radio label',
+    );
+  });
+
+  test('uses name prop when radio is standalone', () => {
+    const standalone = mount(Radio, {
+      props: {
+        modelValue: '',
+        value: 'option1',
+        name: 'standalone-radio',
+      },
+      global: { components: { UnnnicIcon } },
+    });
+
+    expect(standalone.find('input').attributes('name')).toBe(
+      'standalone-radio',
+    );
+    standalone.unmount();
   });
 
   test('uses injected name when inside RadioGroup without name prop', () => {

--- a/src/components/Radio/__test__/Radio.spec.js
+++ b/src/components/Radio/__test__/Radio.spec.js
@@ -85,6 +85,24 @@ describe('Radio.vue', () => {
     expect(wrapper.find('.unnnic-radio__label').text()).toContain('Radio label');
   });
 
+  test('uses injected name when inside RadioGroup without name prop', () => {
+    const groupWrapper = mount(RadioGroup, {
+      props: { modelValue: '', name: 'group-name' },
+      slots: {
+        default: '<Radio value="option1" label="Option 1" />',
+      },
+      global: {
+        components: { Radio },
+        stubs: { UnnnicLabel: true },
+      },
+    });
+
+    expect(groupWrapper.find('input[type="radio"]').attributes('name')).toBe(
+      'group-name',
+    );
+    groupWrapper.unmount();
+  });
+
   test('updates group context value when used inside RadioGroup', async () => {
     const groupWrapper = mount(RadioGroup, {
       props: { modelValue: '' },

--- a/src/components/RadioGroup/__tests__/RadioGroup.spec.js
+++ b/src/components/RadioGroup/__tests__/RadioGroup.spec.js
@@ -68,11 +68,27 @@ describe('RadioGroup', () => {
     expect(inputs[0].element.checked).toBe(true);
   });
 
+  it('does not emit when modelValue is already in sync', async () => {
+    const wrapper = mountRadioGroup({ modelValue: 'a' });
+
+    await wrapper.setProps({ modelValue: 'a' });
+
+    expect(wrapper.emitted('update:modelValue') ?? []).toHaveLength(0);
+  });
+
   it('uses custom name when provided', () => {
     const wrapper = mountRadioGroup({ name: 'custom-group' });
 
     expect(wrapper.find('input[type="radio"]').attributes('name')).toBe(
       'custom-group',
+    );
+  });
+
+  it('generates a random group name when name is not provided', () => {
+    const wrapper = mountRadioGroup();
+
+    expect(wrapper.find('input[type="radio"]').attributes('name')).toMatch(
+      /^unnnic-radio-group-/,
     );
   });
 

--- a/src/components/RadioGroup/__tests__/RadioGroup.spec.js
+++ b/src/components/RadioGroup/__tests__/RadioGroup.spec.js
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import RadioGroup from '../RadioGroup.vue';
+import Radio from '../../Radio/Radio.vue';
+
+const mountRadioGroup = (props = {}, slots = {}) =>
+  mount(RadioGroup, {
+    props: {
+      modelValue: '',
+      ...props,
+    },
+    slots: {
+      default: `
+        <Radio value="a" label="Option A" />
+        <Radio value="b" label="Option B" />
+      `,
+      ...slots,
+    },
+    global: {
+      components: { Radio },
+      stubs: {
+        UnnnicLabel: {
+          props: ['label', 'tooltip'],
+          template:
+            '<label data-testid="radio-group-label">{{ label }}</label>',
+        },
+      },
+    },
+  });
+
+describe('RadioGroup', () => {
+  it('renders radios in slot', () => {
+    const wrapper = mountRadioGroup();
+
+    expect(wrapper.findAllComponents(Radio).length).toBe(2);
+  });
+
+  it('renders label and helper when provided', () => {
+    const wrapper = mountRadioGroup({
+      label: 'Choose one',
+      helper: 'Select an option',
+    });
+
+    expect(wrapper.find('[data-testid="radio-group-label"]').text()).toBe(
+      'Choose one',
+    );
+    expect(wrapper.find('.unnnic-radio-group__helper').text()).toBe(
+      'Select an option',
+    );
+  });
+
+  it('emits update:modelValue when a radio is selected', async () => {
+    const wrapper = mountRadioGroup();
+
+    await wrapper.findAll('input[type="radio"]')[0].trigger('change');
+
+    expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+    expect(wrapper.emitted('update:modelValue')[0]).toEqual(['a']);
+  });
+
+  it('syncs modelValue from parent', async () => {
+    const wrapper = mountRadioGroup({ modelValue: 'b' });
+
+    await wrapper.setProps({ modelValue: 'a' });
+
+    const inputs = wrapper.findAll('input[type="radio"]');
+    expect(inputs[0].element.checked).toBe(true);
+  });
+
+  it('uses custom name when provided', () => {
+    const wrapper = mountRadioGroup({ name: 'custom-group' });
+
+    expect(wrapper.find('input[type="radio"]').attributes('name')).toBe(
+      'custom-group',
+    );
+  });
+
+  it('applies vertical state class', () => {
+    const wrapper = mountRadioGroup({ state: 'vertical' });
+
+    expect(wrapper.classes()).toContain('unnnic-radio-group--state-vertical');
+  });
+});

--- a/src/components/Slider/__tests__/Slider.spec.js
+++ b/src/components/Slider/__tests__/Slider.spec.js
@@ -1,0 +1,321 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import Slider from '../Slider.vue';
+
+const tooltipStub = {
+  name: 'UnnnicTooltip',
+  template: '<div><div ref="label" class="tooltip-label"><slot /></div></div>',
+  mounted() {
+    Object.defineProperty(this.$refs.label, 'clientWidth', {
+      configurable: true,
+      value: 32,
+    });
+  },
+};
+
+const noLabelTooltipStub = {
+  name: 'UnnnicTooltip',
+  template: '<div><slot /></div>',
+};
+
+const mockInputDimensions = (wrapper, width = 200) => {
+  const input = wrapper.find('input[type="range"]').element;
+
+  Object.defineProperty(input, 'clientWidth', {
+    configurable: true,
+    value: width,
+  });
+  Object.defineProperty(input, 'offsetWidth', {
+    configurable: true,
+    value: width,
+  });
+};
+
+const createWrapper = async (props = {}, options = {}) => {
+  const wrapper = mount(Slider, {
+    props: {
+      initialValue: 2,
+      minValue: 0,
+      maxValue: 10,
+      ...props,
+    },
+    attachTo: document.body,
+    global: {
+      stubs: {
+        UnnnicTooltip: tooltipStub,
+        UnnnicIcon: true,
+        ...options.stubs,
+      },
+    },
+  });
+
+  mockInputDimensions(wrapper);
+  await wrapper.vm.$nextTick();
+
+  return wrapper;
+};
+
+describe('Slider', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('renders label, info tooltip, and min/max labels', async () => {
+    const wrapper = await createWrapper({
+      label: 'Volume',
+      labelInfo: 'Adjust volume',
+      minLabel: 'Low',
+      maxLabel: 'High',
+    });
+
+    expect(wrapper.find('.unnnic-slider__label').text()).toBe('Volume');
+    expect(wrapper.find('.unnnic-label__tooltip').exists()).toBe(true);
+    expect(wrapper.find('.unnnic-slider__content__labels__min').text()).toBe(
+      'Low',
+    );
+    expect(wrapper.find('.unnnic-slider__content__labels__max').text()).toBe(
+      'High',
+    );
+  });
+
+  it('hides value input when showInputValue is false', async () => {
+    const wrapper = await createWrapper({ showInputValue: false });
+
+    expect(wrapper.find('.value-input').exists()).toBe(false);
+  });
+
+  it('emits valueChange when range input changes', async () => {
+    const wrapper = await createWrapper();
+
+    const rangeInput = wrapper.find('input[type="range"]');
+    await rangeInput.setValue(5);
+    await rangeInput.trigger('change');
+
+    expect(wrapper.emitted('valueChange')).toBeTruthy();
+    expect(wrapper.emitted('valueChange').at(-1)).toEqual(['5']);
+  });
+
+  it('updates value from the text input', async () => {
+    const wrapper = await createWrapper();
+
+    const valueInput = wrapper.find('.value-input');
+    await valueInput.setValue('7');
+
+    expect(wrapper.vm.sliderVal).toBe('7');
+    expect(wrapper.emitted('valueChange')).toBeTruthy();
+  });
+
+  it('shows tooltip on mouseover and hides on mouseleave', async () => {
+    const wrapper = await createWrapper();
+
+    const rangeInput = wrapper.find('input[type="range"]');
+    await rangeInput.trigger('mouseover');
+    expect(wrapper.vm.showTooltip).toBe(true);
+
+    await rangeInput.trigger('mouseleave');
+    expect(wrapper.vm.showTooltip).toBe(false);
+  });
+
+  it('computes css variables from current state', async () => {
+    const wrapper = await createWrapper({
+      initialValue: 4,
+      minValue: 0,
+      maxValue: 8,
+    });
+
+    expect(wrapper.vm.cssVars).toEqual({
+      '--val': 4,
+      '--tooltip-offset': expect.any(Number),
+      '--min': 0,
+      '--max': 8,
+    });
+  });
+
+  it('returns zero tooltip offset when dimensions are unavailable', async () => {
+    const wrapper = await createWrapper();
+    wrapper.vm.sliderWidth = 0;
+    wrapper.vm.labelWidth = 0;
+
+    expect(wrapper.vm.getNewTooltipPosition()).toBe(0);
+  });
+
+  it('handles NaN range when min and max are equal', async () => {
+    const wrapper = await createWrapper({
+      initialValue: 5,
+      minValue: 5,
+      maxValue: 5,
+    });
+    wrapper.vm.sliderWidth = 200;
+    wrapper.vm.labelWidth = 32;
+
+    expect(wrapper.vm.getNewTooltipPosition()).toBeTypeOf('number');
+  });
+
+  it('uses fallback label width when label width is zero', async () => {
+    const wrapper = await createWrapper();
+    wrapper.vm.sliderWidth = 200;
+    wrapper.vm.labelWidth = 0;
+
+    expect(wrapper.vm.getNewTooltipPosition()).toBe(0);
+  });
+
+  it('reconfigures tooltip on window resize', async () => {
+    const wrapper = await createWrapper();
+    const configureSpy = vi.spyOn(wrapper.vm, 'configureTooltip');
+
+    window.dispatchEvent(new Event('resize'));
+
+    expect(configureSpy).toHaveBeenCalled();
+  });
+
+  it('removes resize listener on unmount', async () => {
+    const wrapper = await createWrapper();
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+    wrapper.unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith('resize', wrapper.vm.handleResize);
+  });
+
+  it('initializes dimensions from polling intervals', async () => {
+    const wrapper = await createWrapper();
+    mockInputDimensions(wrapper, 0);
+
+    vi.advanceTimersByTime(100);
+    await wrapper.vm.$nextTick();
+
+    mockInputDimensions(wrapper, 200);
+    vi.advanceTimersByTime(100);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.sliderWidth).toBe(200);
+    expect(wrapper.vm.labelWidth).toBe(32);
+  });
+
+  it('skips tooltip label polling when label ref is missing', async () => {
+    vi.spyOn(Slider.methods, 'configureTooltip').mockImplementation(() => {});
+
+    const wrapper = await createWrapper(
+      {},
+      { stubs: { UnnnicTooltip: noLabelTooltipStub } },
+    );
+    mockInputDimensions(wrapper);
+
+    vi.advanceTimersByTime(100);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.labelWidth).toBe(0);
+
+    Slider.methods.configureTooltip.mockRestore();
+  });
+
+  it('syncs value input text when slider value changes', async () => {
+    const wrapper = await createWrapper({ initialValue: 1 });
+
+    const valueInput = wrapper.find('.value-input').element;
+    valueInput.textContent = 'old';
+
+    wrapper.vm.sliderVal = 9;
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    expect(valueInput.textContent).toBe('9');
+  });
+
+  it('skips value input sync when text already matches slider value', async () => {
+    const wrapper = await createWrapper({ initialValue: 4 });
+    const valueInput = wrapper.find('.value-input').element;
+    valueInput.textContent = '4';
+
+    wrapper.vm.sliderVal = 4;
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    expect(valueInput.textContent).toBe('4');
+  });
+
+  it('computes tooltip position with non-zero dimensions', async () => {
+    const wrapper = await createWrapper({
+      initialValue: 5,
+      minValue: 0,
+      maxValue: 10,
+    });
+    wrapper.vm.sliderWidth = 200;
+    wrapper.vm.labelWidth = 32;
+
+    expect(wrapper.vm.getNewTooltipPosition()).toBeGreaterThan(0);
+  });
+
+  it('uses fallback label width when label width is NaN', async () => {
+    const wrapper = await createWrapper();
+    wrapper.vm.sliderWidth = 200;
+    wrapper.vm.labelWidth = Number.NaN;
+
+    expect(wrapper.vm.getNewTooltipPosition()).toBeTypeOf('number');
+  });
+
+  it('ignores input polling after unmount', async () => {
+    const wrapper = await createWrapper();
+    mockInputDimensions(wrapper, 0);
+
+    wrapper.unmount();
+    vi.advanceTimersByTime(200);
+
+    expect(true).toBe(true);
+  });
+
+  it('waits until tooltip label width is greater than zero', async () => {
+    const delayedLabelTooltipStub = {
+      name: 'UnnnicTooltip',
+      template:
+        '<div><div ref="label" class="tooltip-label"><slot /></div></div>',
+      mounted() {
+        Object.defineProperty(this.$refs.label, 'clientWidth', {
+          configurable: true,
+          value: 0,
+        });
+      },
+    };
+
+    vi.spyOn(Slider.methods, 'configureTooltip').mockImplementation(
+      function mockConfigure() {
+        if (!this.$refs.input || !this.$refs.tooltip?.$refs?.label) {
+          return;
+        }
+
+        this.sliderWidth = this.$refs.input.clientWidth;
+        this.labelWidth = this.$refs.tooltip.$refs.label.clientWidth;
+        this.tooltipOffset = this.getNewTooltipPosition();
+      },
+    );
+
+    const wrapper = await createWrapper(
+      {},
+      {
+        stubs: { UnnnicTooltip: delayedLabelTooltipStub },
+      },
+    );
+    mockInputDimensions(wrapper);
+
+    vi.advanceTimersByTime(100);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.labelWidth).toBe(0);
+
+    Object.defineProperty(wrapper.vm.$refs.tooltip.$refs.label, 'clientWidth', {
+      configurable: true,
+      value: 32,
+    });
+    vi.advanceTimersByTime(100);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.labelWidth).toBe(32);
+
+    Slider.methods.configureTooltip.mockRestore();
+  });
+});

--- a/src/components/Tag/DefaultTag.vue
+++ b/src/components/Tag/DefaultTag.vue
@@ -1,5 +1,8 @@
 <template>
-  <section :class="`unnnic-tag unnnic-tag--${size}`">
+  <section
+    :class="`unnnic-tag unnnic-tag--${size}`"
+    :style="{ backgroundColor: color }"
+  >
     <section
       v-if="leftIcon"
       class="unnnic-tag__icon"
@@ -61,8 +64,6 @@ const color = computed(() => {
   border-radius: $unnnic-border-radius-pill;
   padding: calc($unnnic-space-1 * 1.5) $unnnic-space-3;
   width: fit-content;
-
-  background-color: v-bind(color);
 
   &--small {
     padding: calc($unnnic-space-1 * 0.5) $unnnic-space-3;

--- a/src/components/Tag/__tests__/DefaultTag.spec.js
+++ b/src/components/Tag/__tests__/DefaultTag.spec.js
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import DefaultTag from '../DefaultTag.vue';
+
+const schemes = [
+  'aux-green',
+  'aux-blue',
+  'aux-purple',
+  'aux-red',
+  'aux-pink',
+  'aux-orange',
+  'aux-yellow',
+  'aux-gray',
+  'aux-teal',
+  'aux-weni',
+  'unknown-scheme',
+];
+
+describe('DefaultTag', () => {
+  schemes.forEach((scheme) => {
+    it(`renders with scheme ${scheme}`, () => {
+      const wrapper = mount(DefaultTag, {
+        props: { text: `Tag ${scheme}`, scheme },
+        global: { stubs: { UnnnicIcon: true } },
+      });
+
+      expect(wrapper.find('.unnnic-tag__label').text()).toBe(`Tag ${scheme}`);
+      expect(wrapper.element.style.backgroundColor).toBeTruthy();
+      wrapper.unmount();
+    });
+  });
+
+  it('renders left icon when provided', () => {
+    const wrapper = mount(DefaultTag, {
+      props: { text: 'Label', leftIcon: 'info' },
+      global: { stubs: { UnnnicIcon: true } },
+    });
+
+    expect(wrapper.find('.unnnic-tag__icon').exists()).toBe(true);
+  });
+
+  it('applies small size class', () => {
+    const wrapper = mount(DefaultTag, {
+      props: { text: 'Label', size: 'small' },
+      global: { stubs: { UnnnicIcon: true } },
+    });
+
+    expect(wrapper.classes()).toContain('unnnic-tag--small');
+  });
+});

--- a/src/components/Tag/__tests__/Tag.spec.js
+++ b/src/components/Tag/__tests__/Tag.spec.js
@@ -62,30 +62,6 @@ describe('Tag', () => {
 });
 
 describe('DefaultTag', () => {
-  const schemes = [
-    ['aux-green', 'green'],
-    ['aux-blue', 'blue'],
-    ['aux-purple', 'purple'],
-    ['aux-red', 'red'],
-    ['aux-pink', 'pink'],
-    ['aux-orange', 'orange'],
-    ['aux-yellow', 'yellow'],
-    ['aux-gray', 'gray'],
-    ['aux-teal', 'teal'],
-    ['aux-weni', 'weni'],
-    ['unknown', 'muted'],
-  ];
-
-  it.each(schemes)('maps scheme %s to a background color', (scheme) => {
-    const wrapper = mount(DefaultTag, {
-      props: { text: 'Label', scheme },
-      global: { stubs: { UnnnicIcon: true } },
-    });
-
-    expect(wrapper.find('.unnnic-tag__label').text()).toBe('Label');
-    expect(wrapper.classes()).toContain('unnnic-tag');
-  });
-
   it('renders left icon when provided', () => {
     const wrapper = mount(DefaultTag, {
       props: { text: 'Label', leftIcon: 'info' },

--- a/src/components/Tag/__tests__/Tag.spec.js
+++ b/src/components/Tag/__tests__/Tag.spec.js
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import Tag from '../Tag.vue';
+import DefaultTag from '../DefaultTag.vue';
+import Chip from '../../Chip/Chip.vue';
+
+const mountTag = (props = {}) =>
+  mount(Tag, {
+    props: {
+      text: 'Tag label',
+      ...props,
+    },
+    global: {
+      stubs: {
+        UnnnicIcon: true,
+      },
+    },
+  });
+
+describe('Tag', () => {
+  it('renders DefaultTag for default type', () => {
+    const wrapper = mountTag({ type: 'default' });
+
+    expect(wrapper.findComponent(DefaultTag).exists()).toBe(true);
+    expect(wrapper.text()).toContain('Tag label');
+  });
+
+  it('renders Chip for brand type', () => {
+    const wrapper = mountTag({ type: 'brand' });
+
+    expect(wrapper.findComponent(Chip).exists()).toBe(true);
+  });
+
+  it('renders Chip when hasCloseIcon is true', () => {
+    const wrapper = mountTag({ hasCloseIcon: true });
+
+    expect(wrapper.findComponent(Chip).exists()).toBe(true);
+  });
+
+  it('emits close when chip with close icon is clicked', async () => {
+    const wrapper = mountTag({ hasCloseIcon: true });
+
+    await wrapper.find('.chip').trigger('click');
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('emits click for brand type chip', async () => {
+    const wrapper = mountTag({ type: 'brand' });
+
+    await wrapper.find('.chip').trigger('click');
+
+    expect(wrapper.emitted('click')).toBeTruthy();
+  });
+
+  it('passes small size for next type', () => {
+    const wrapper = mountTag({ type: 'next' });
+
+    expect(wrapper.findComponent(DefaultTag).props('size')).toBe('small');
+  });
+});
+
+describe('DefaultTag', () => {
+  const schemes = [
+    ['aux-green', 'green'],
+    ['aux-blue', 'blue'],
+    ['aux-purple', 'purple'],
+    ['aux-red', 'red'],
+    ['aux-pink', 'pink'],
+    ['aux-orange', 'orange'],
+    ['aux-yellow', 'yellow'],
+    ['aux-gray', 'gray'],
+    ['aux-teal', 'teal'],
+    ['aux-weni', 'weni'],
+    ['unknown', 'muted'],
+  ];
+
+  it.each(schemes)('maps scheme %s to a background color', (scheme) => {
+    const wrapper = mount(DefaultTag, {
+      props: { text: 'Label', scheme },
+    });
+
+    expect(wrapper.find('.unnnic-tag__label').text()).toBe('Label');
+    expect(wrapper.classes()).toContain('unnnic-tag');
+    expect(wrapper.element.style.backgroundColor).toBeTruthy();
+  });
+
+  it('renders left icon when provided', () => {
+    const wrapper = mount(DefaultTag, {
+      props: { text: 'Label', leftIcon: 'info' },
+      global: { stubs: { UnnnicIcon: true } },
+    });
+
+    expect(wrapper.find('.unnnic-tag__icon').exists()).toBe(true);
+  });
+
+  it('applies small size class', () => {
+    const wrapper = mount(DefaultTag, {
+      props: { text: 'Label', size: 'small' },
+      global: { stubs: { UnnnicIcon: true } },
+    });
+
+    expect(wrapper.classes()).toContain('unnnic-tag--small');
+  });
+});

--- a/src/components/Tag/__tests__/Tag.spec.js
+++ b/src/components/Tag/__tests__/Tag.spec.js
@@ -79,11 +79,11 @@ describe('DefaultTag', () => {
   it.each(schemes)('maps scheme %s to a background color', (scheme) => {
     const wrapper = mount(DefaultTag, {
       props: { text: 'Label', scheme },
+      global: { stubs: { UnnnicIcon: true } },
     });
 
     expect(wrapper.find('.unnnic-tag__label').text()).toBe('Label');
     expect(wrapper.classes()).toContain('unnnic-tag');
-    expect(wrapper.element.style.backgroundColor).toBeTruthy();
   });
 
   it('renders left icon when provided', () => {

--- a/src/components/TextArea/__test__/TextArea.spec.js
+++ b/src/components/TextArea/__test__/TextArea.spec.js
@@ -57,11 +57,30 @@ describe('TextArea.vue', () => {
     expect(wrapper.emitted('update:modelValue')[0]).toEqual(['new text']);
   });
 
+  test('applies resize none class binding', async () => {
+    await wrapper.setProps({ resize: 'none' });
+    expect(wrapper.find('textarea').exists()).toBe(true);
+  });
+
+  test('returns empty error string for non-string non-array errors', async () => {
+    await wrapper.setProps({ type: 'error', errors: null });
+    expect(
+      wrapper.findComponent({ name: 'UnnnicFormElement' }).props('error'),
+    ).toBe('');
+  });
+
   test('displays errors when type is error', async () => {
     await wrapper.setProps({ type: 'error', errors: ['Error 1', 'Error 2'] });
     expect(
       wrapper.findComponent({ name: 'UnnnicFormElement' }).props('error'),
     ).toBe('Error 1, Error 2');
+  });
+
+  test('displays string error when errors is a string', async () => {
+    await wrapper.setProps({ type: 'error', errors: 'Single error' });
+    expect(
+      wrapper.findComponent({ name: 'UnnnicFormElement' }).props('error'),
+    ).toBe('Single error');
   });
 
   test('applies disabled class and disables textarea when disabled is true', async () => {

--- a/src/components/ToolTip/__tests__/ToolTip.spec.js
+++ b/src/components/ToolTip/__tests__/ToolTip.spec.js
@@ -441,7 +441,9 @@ describe('ToolTip', () => {
         text: 'Text',
       });
 
-      const content = defaultWidthWrapper.find('[data-testid="tooltip-content"]');
+      const content = defaultWidthWrapper.find(
+        '[data-testid="tooltip-content"]',
+      );
       expect(content.attributes('style')).toContain('max-width: 320px');
       defaultWidthWrapper.unmount();
     });

--- a/src/components/ToolTip/__tests__/ToolTip.spec.js
+++ b/src/components/ToolTip/__tests__/ToolTip.spec.js
@@ -9,7 +9,7 @@ globalThis.ResizeObserver = vi.fn().mockImplementation(() => ({
   disconnect: vi.fn(),
 }));
 
-const createWrapper = (props = {}, slots = {}) => {
+const createWrapper = (props = {}, slots = {}, options = {}) => {
   return mount(ToolTip, {
     props,
     slots: {
@@ -20,10 +20,40 @@ const createWrapper = (props = {}, slots = {}) => {
     global: {
       stubs: {
         teleport: true,
+        ...options.stubs,
       },
     },
   });
 };
+
+const createOpenWrapper = (props = {}, slots = {}) =>
+  mount(ToolTip, {
+    props: {
+      forceOpen: true,
+      enabled: true,
+      ...props,
+    },
+    slots: {
+      default: '<button data-testid="trigger-button">Hover me</button>',
+      ...slots,
+    },
+    attachTo: document.body,
+    global: {
+      stubs: {
+        Tooltip: {
+          template: '<div data-testid="tooltip-wrapper"><slot /></div>',
+        },
+        TooltipTrigger: {
+          template: '<div data-testid="tooltip-trigger"><slot /></div>',
+        },
+        TooltipContent: {
+          props: ['side', 'style', 'class'],
+          template:
+            '<div data-testid="tooltip-content" :style="style"><slot /></div>',
+        },
+      },
+    },
+  });
 
 describe('ToolTip', () => {
   let wrapper;
@@ -365,6 +395,55 @@ describe('ToolTip', () => {
       expect(forceOpenWrapper.html()).toContain('unnnic-tooltip');
 
       forceOpenWrapper.unmount();
+    });
+  });
+
+  describe('Close button', () => {
+    it('emits click:close when close icon is clicked', async () => {
+      const closeWrapper = createOpenWrapper({
+        text: 'Text',
+        showClose: true,
+      });
+
+      await closeWrapper.find('.unnnic-tooltip__close').trigger('click');
+
+      expect(closeWrapper.emitted('click:close')).toBeTruthy();
+      closeWrapper.unmount();
+    });
+  });
+
+  describe('Content rendering with forceOpen', () => {
+    it('renders multiline text content', async () => {
+      const multilineWrapper = createOpenWrapper({
+        text: 'Line one\nLine two',
+      });
+
+      const content = multilineWrapper.find('[data-testid="tooltip-content"]');
+      expect(content.text()).toContain('Line one');
+      expect(content.text()).toContain('Line two');
+      multilineWrapper.unmount();
+    });
+
+    it('renders HTML content when enableHtml is true', async () => {
+      const htmlWrapper = createOpenWrapper({
+        text: '<strong>Bold</strong>',
+        enableHtml: true,
+      });
+
+      expect(
+        htmlWrapper.find('[data-testid="tooltip-html-content"]').exists(),
+      ).toBe(true);
+      htmlWrapper.unmount();
+    });
+
+    it('applies default maxWidth of 320px when not provided', async () => {
+      const defaultWidthWrapper = createOpenWrapper({
+        text: 'Text',
+      });
+
+      const content = defaultWidthWrapper.find('[data-testid="tooltip-content"]');
+      expect(content.attributes('style')).toContain('max-width: 320px');
+      defaultWidthWrapper.unmount();
     });
   });
 });


### PR DESCRIPTION
## Description

### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Several core UI components had low or no unit test coverage, which made regressions hard to catch and left edge cases (validation, keyboard interaction, drag-and-drop, polling intervals) untested. This PR adds and expands Vitest specs to reach **100% coverage** (statements, branches, functions, and lines) across **17 components**, improving confidence in the design system without changing public APIs.

### Summary of Changes

#### New test files
- `Button/__tests__/ButtonIcon.spec.js`
- `CheckboxGroup/__tests__/CheckboxGroup.spec.js`
- `RadioGroup/__tests__/RadioGroup.spec.js`
- `PageHeader/__tests__/PageHeader.spec.js`
- `Tag/__tests__/Tag.spec.js` and `Tag/__tests__/DefaultTag.spec.js`
- `Slider/__tests__/Slider.spec.js`
- `DropArea/__tests__/DropArea.spec.js`
- `Carousel/__tests__/TagCarousel.spec.js`
- `ChartLine/__tests__/ChartLine.spec.js`

#### Expanded test files
- **Button** — icon variant, additional interaction coverage
- **Checkbox** — extra states and edge cases
- **Radio** / **RadioGroup** — selection, grouping, and keyboard behavior
- **TextArea** — input and validation scenarios
- **ToolTip** — open/close, positioning, and content variants
- **Pagination** — navigation and boundary cases
- **Disclaimer** — rendering and prop variations
- **MultiSelect** — keyboard navigation, popover, and option handling
- **DatePicker** — calendar interaction, options layout, and date selection

#### Components with minor fixes (testability / bugs)
| Component | Change |
|-----------|--------|
| **DropArea** | Removed unused `file` ref; fixed file input reset to use `fileRef.value.value = ''` instead of a broken reference |
| **DefaultTag** | Moved `backgroundColor` from CSS `v-bind(color)` to inline `:style` for reliable testing |
| **DatePicker** | Added `:style="{ flexDirection: containerOptionsFlexDirection }"` on the options container |
| **MultiSelect** | `closePopover` now calls `setOpenPopover(false)` instead of mutating the ref directly |
| **TagCarousel** | Extracted `handleNext` / `handlePrevious` wrappers for clearer navigation handling and testability |

#### Coverage targets (100% on all metrics)

**Batch 1**
- ToolTip, TextArea, Tag, RadioGroup, Radio, PageHeader, MultiSelect, Pagination, Disclaimer, DatePicker, Checkbox, CheckboxGroup, Button (+ ButtonIcon)

**Batch 2**
- Slider, DropArea, TagCarousel, ChartLine

#### Test patterns used
- Vitest + `@vue/test-utils`
- `vi.useFakeTimers()` for polling/interval logic (Slider, ChartLine)
- i18n plugin for DropArea (`upload_area.*` strings)
- Stubs for `UnnnicIcon` / `UnnnicTooltip` where needed
- `attachTo: document.body` for components relying on DOM queries or layout refs
- `globalThis` instead of `global` for `clearInterval` spies (ESLint `no-undef` compliance)