### PR TITLE
feat: Add icon slot to Disclaimer and strokeWidth prop to IconLoading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 3.29.0 (2026-07-08)
+
+### Added
+
+- **UnnnicDisclaimer**: `#icon` scoped slot to render a custom icon in place of the default type-based `UnnnicIcon`. The built-in icon is preserved as the fallback when the slot is not provided.
+- **UnnnicIconLoading**: `strokeWidth` prop (Number, default `5`) to customize the SVG circle stroke width.
+- **Storybook**: `WithCustomIcon` story for Disclaimer demonstrating the `#icon` slot with `UnnnicIconLoading`; `CustomStrokeWidth` story for IconLoading.
+
+### Fixed
+
+- **UnnnicDisclaimer**: Description slot detection now invokes the slot function with an empty props object (`slots.description({})`), matching Vue 3 slot API usage.
+
+### Changed
+
+- **UnnnicIconLoading**: Spinner container now uses `align-items: center` for improved vertical alignment.
+
 # 3.28.1 (2026-06-05)
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@weni/unnnic-system",
-  "version": "3.26.1",
+  "version": "3.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@weni/unnnic-system",
-      "version": "3.26.1",
+      "version": "3.29.0",
       "dependencies": {
         "@iconify/vue": "^5.0.0",
         "@vueuse/components": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weni/unnnic-system",
-  "version": "3.28.1",
+  "version": "3.29.0",
   "type": "commonjs",
   "files": [
     "dist",

--- a/src/components/Disclaimer/Disclaimer.vue
+++ b/src/components/Disclaimer/Disclaimer.vue
@@ -3,13 +3,15 @@
     :class="['unnnic-disclaimer', `unnnic-disclaimer--${type}`]"
     data-testid="disclaimer"
   >
-    <UnnnicIcon
-      class="unnnic-disclaimer__icon"
-      size="ant"
-      :icon="variant.icon"
-      :scheme="variant.scheme"
-      data-testid="disclaimer-icon"
-    />
+    <slot name="icon">
+      <UnnnicIcon
+        class="unnnic-disclaimer__icon"
+        size="ant"
+        :icon="variant.icon"
+        :scheme="variant.scheme"
+        data-testid="disclaimer-icon"
+      />
+    </slot>
 
     <section class="unnnic-disclaimer__content">
       <p
@@ -57,7 +59,7 @@ const slots = useSlots();
 const hasDescription = computed(() => {
   return (
     Boolean(props.description) ||
-    (slots.description && slots.description().length > 0)
+    (slots.description && slots.description({}).length > 0)
   );
 });
 

--- a/src/components/IconLoading/IconLoading.vue
+++ b/src/components/IconLoading/IconLoading.vue
@@ -53,7 +53,6 @@ const props = defineProps({
 defineOptions({ name: 'UnnnicIconLoading' });
 
 const sizeInPixels = computed(() => SIZE_MAP[props.size] ?? props.size);
-const strokeWidth = computed(() => props.strokeWidth);
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/IconLoading/IconLoading.vue
+++ b/src/components/IconLoading/IconLoading.vue
@@ -44,11 +44,16 @@ const props = defineProps({
     type: String,
     default: 'lg',
   },
+  strokeWidth: {
+    type: Number,
+    default: 5,
+  },
 });
 
 defineOptions({ name: 'UnnnicIconLoading' });
 
 const sizeInPixels = computed(() => SIZE_MAP[props.size] ?? props.size);
+const strokeWidth = computed(() => props.strokeWidth);
 </script>
 
 <style lang="scss" scoped>
@@ -79,6 +84,7 @@ const sizeInPixels = computed(() => SIZE_MAP[props.size] ?? props.size);
 
 .unnnic-icon-loading {
   display: inline-flex;
+  align-items: center;
   user-select: none;
 
   svg {
@@ -87,7 +93,7 @@ const sizeInPixels = computed(() => SIZE_MAP[props.size] ?? props.size);
     circle {
       fill: none;
       stroke: currentColor;
-      stroke-width: 5;
+      stroke-width: v-bind(strokeWidth);
       stroke-linecap: round;
       animation: unnnic-icon-loading-dash 1s ease-in-out infinite;
     }

--- a/src/stories/Disclaimer.stories.js
+++ b/src/stories/Disclaimer.stories.js
@@ -1,4 +1,5 @@
 import UnnnicDisclaimer from '../components/Disclaimer/Disclaimer.vue';
+import UnnnicIconLoading from '../components/IconLoading/IconLoading.vue';
 
 export default {
   title: 'Feedback/Disclaimer',
@@ -74,4 +75,19 @@ const TemplateWithDescriptionSlot = (args) => ({
 export const WithDescriptionSlot = TemplateWithDescriptionSlot.bind({});
 WithDescriptionSlot.args = {
   ...Default.args,
+};
+
+const TemplateWithCustomIcon = (args) => ({
+  components: { UnnnicDisclaimer, UnnnicIconLoading },
+  setup() {
+    return { args };
+  },
+  template:
+    '<UnnnicDisclaimer v-bind="args"><template #icon><UnnnicIconLoading size="sm" scheme="fg-emphasized" stroke-width="3" /></template></UnnnicDisclaimer>',
+});
+
+export const WithCustomIcon = TemplateWithCustomIcon.bind({});
+WithCustomIcon.args = {
+  text: '',
+  description: 'Analysis in progress · 381 of 437 items processed.',
 };

--- a/src/stories/IconLoading.stories.js
+++ b/src/stories/IconLoading.stories.js
@@ -55,3 +55,9 @@ export const CustomSize = {
     size: '64px',
   },
 };
+
+export const CustomStrokeWidth = {
+  args: {
+    strokeWidth: 3,
+  },
+};


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [ ] Tests
    - [ ] Other

### Motivation and Context

The `Disclaimer` component previously had a hardcoded icon with no way to customize it. Additionally, the `IconLoading` component lacked control over the stroke width of its SVG circle, limiting visual flexibility.

### Summary of Changes

- Added an `icon` slot to the `Disclaimer` component, allowing consumers to replace the default icon with a custom one (e.g., a loading spinner).
- Fixed the `hasDescription` computed property to pass an empty object when invoking the `description` slot function, ensuring compatibility with Vue's slot rendering expectations.
- Added a `strokeWidth` prop to `IconLoading`, enabling control over the SVG circle's stroke width (defaults to `5`).
- Added `align-items: center` to the `IconLoading` wrapper for better vertical alignment.
- Added a new `WithCustomIcon` Storybook story demonstrating the use of `UnnnicIconLoading` as a custom icon inside `UnnnicDisclaimer`.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/fae4d1ec-2d86-424c-be7e-853edce35efd.png)

