### PR TITLE
feat(Table): Add version 2 with new UI table components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 3.30.0 (2026-07-08)
+
+### Added
+
+- **UnnnicTable**: `version` prop (String, default `'1'`). When set to `'2'`, renders a semantic HTML table via the new composition API. Version `'1'` preserves the existing slot-based layout unchanged. Provides `unnnicTableVersion` via `provide` so child components can adapt.
+- **UnnnicTableRow**: When the parent table `version` is `'2'`, delegates rendering to the new `UiTableRow` primitive. Legacy header-driven row layout is preserved for version `'1'`.
+- **UnnnicTableBody**, **UnnnicTableCell**, **UnnnicTableHead**, **UnnnicTableHeader**: New table primitives (`<tbody>`, `<td>`, `<th>`, `<thead>`) with design-token styling. Registered in the plugin map and exported (`unnnicTableBody` / `UnnnicTableBody`, etc.).
+- **UiTable** (internal): Semantic `<table>` wrapper with overflow scrolling, border-collapse, and body typography tokens.
+- **UiTableRow** (internal): Row with bottom border, hover background (`bg-soft`), horizontal padding on first/last cells, and `cursor-pointer` when a `click` listener is bound.
+- **Storybook**: `Version2` story demonstrating the composition API with `TableHeader`, `TableBody`, `TableHead`, `TableCell`, tags, and clickable rows. `version` control added to argTypes.
+
 # 3.29.0 (2026-07-08)
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@weni/unnnic-system",
-  "version": "3.29.0",
+  "version": "3.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@weni/unnnic-system",
-      "version": "3.29.0",
+      "version": "3.30.0",
       "dependencies": {
         "@iconify/vue": "^5.0.0",
         "@vueuse/components": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weni/unnnic-system",
-  "version": "3.29.0",
+  "version": "3.30.0",
   "type": "commonjs",
   "files": [
     "dist",

--- a/src/components/Table/Table.vue
+++ b/src/components/Table/Table.vue
@@ -1,6 +1,10 @@
 <template>
+  <UiTable v-if="version === '2'">
+    <slot />
+  </UiTable>
+
   <div
-    v-show="true"
+    v-else
     class="unnnic-table"
   >
     <div class="header">
@@ -28,14 +32,29 @@
 </template>
 
 <script>
+import { computed } from 'vue';
+import { Table as UiTable } from '@/components/ui/table';
+
 export default {
   name: 'UnnnicTable',
 
-  components: {},
+  components: {
+    UiTable,
+  },
+
+  provide() {
+    return {
+      unnnicTableVersion: computed(() => this.version),
+    };
+  },
 
   props: {
     items: {
       type: Array,
+    },
+    version: {
+      type: String,
+      default: '1',
     },
   },
 

--- a/src/components/Table/TableRow.vue
+++ b/src/components/Table/TableRow.vue
@@ -1,5 +1,16 @@
 <template>
-  <div class="table-row">
+  <UiTableRow
+    v-if="isVersion2"
+    v-bind="$attrs"
+  >
+    <slot />
+  </UiTableRow>
+
+  <div
+    v-else
+    class="table-row"
+    v-bind="$attrs"
+  >
     <template
       v-for="(header, index) in headers"
       :key="header.id"
@@ -26,8 +37,17 @@
 </template>
 
 <script>
+import { computed, inject, unref } from 'vue';
+import UiTableRow from '@/components/ui/table/TableRow.vue';
+
 export default {
   name: 'UnnnicTableRow',
+
+  components: {
+    UiTableRow,
+  },
+
+  inheritAttrs: false,
 
   props: {
     headers: {
@@ -35,8 +55,13 @@ export default {
     },
   },
 
-  data() {
-    return {};
+  setup() {
+    const tableVersion = inject('unnnicTableVersion', '1');
+    const isVersion2 = computed(() => unref(tableVersion) === '2');
+
+    return {
+      isVersion2,
+    };
   },
 };
 </script>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,6 +10,7 @@ import sidebar from './Sidebar/index.vue';
 import sidebarItem from './Sidebar/SidebarItem.vue';
 import table from './Table/Table.vue';
 import tableRow from './Table/TableRow.vue';
+import { TableBody, TableCell, TableHead, TableHeader } from './ui/table';
 import dropdown from './Dropdown/Dropdown.vue';
 import dropdownItem from './Dropdown/DropdownItem.vue';
 import avatarIcon from './AvatarIcon/AvatarIcon.vue';
@@ -138,6 +139,10 @@ export const components: ComponentsMap = {
   unnnicSidebarItem: sidebarItem,
   unnnicTable: table,
   unnnicTableRow: tableRow,
+  unnnicTableBody: TableBody,
+  unnnicTableCell: TableCell,
+  unnnicTableHead: TableHead,
+  unnnicTableHeader: TableHeader,
   unnnicAvatarIcon: avatarIcon,
   unnnicIcon: icon,
   unnnicIconSvg: icon,
@@ -261,6 +266,10 @@ export const unnnicSidebar = sidebar;
 export const unnnicSidebarItem = sidebarItem;
 export const unnnicTable = table;
 export const unnnicTableRow = tableRow;
+export const unnnicTableBody = TableBody;
+export const unnnicTableCell = TableCell;
+export const unnnicTableHead = TableHead;
+export const unnnicTableHeader = TableHeader;
 export const unnnicDropdown = dropdown as VueComponent;
 export const unnnicDropdownItem = dropdownItem;
 export const unnnicAvatarIcon = avatarIcon;
@@ -383,6 +392,10 @@ export const UnnnicSidebar = sidebar;
 export const UnnnicSidebarItem = sidebarItem;
 export const UnnnicTable = table;
 export const UnnnicTableRow = tableRow;
+export const UnnnicTableBody = TableBody;
+export const UnnnicTableCell = TableCell;
+export const UnnnicTableHead = TableHead;
+export const UnnnicTableHeader = TableHeader;
 export const UnnnicDropdown = dropdown as VueComponent;
 export const UnnnicDropdownItem = dropdownItem;
 export const UnnnicAvatarIcon = avatarIcon;

--- a/src/components/ui/table/Table.vue
+++ b/src/components/ui/table/Table.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue';
+import { cn } from '@/lib/utils';
+
+const props = defineProps<{
+  class?: HTMLAttributes['class'];
+}>();
+</script>
+
+<template>
+  <div class="relative w-full overflow-auto">
+    <table :class="cn('unnnic-table', props.class)">
+      <slot />
+    </table>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/unnnic' as *;
+
+.unnnic-table {
+  border-collapse: collapse;
+  width: 100%;
+  caption-side: bottom;
+
+  @include unnnic-font-body;
+  color: $unnnic-color-fg-base;
+}
+</style>

--- a/src/components/ui/table/TableBody.vue
+++ b/src/components/ui/table/TableBody.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue';
+import { cn } from '@/lib/utils';
+
+const props = defineProps<{
+  class?: HTMLAttributes['class'];
+}>();
+</script>
+
+<template>
+  <tbody :class="cn(props.class)">
+    <slot />
+  </tbody>
+</template>

--- a/src/components/ui/table/TableCell.vue
+++ b/src/components/ui/table/TableCell.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue';
+import { cn } from '@/lib/utils';
+
+const props = defineProps<{
+  class?: HTMLAttributes['class'];
+}>();
+</script>
+
+<template>
+  <td :class="cn('unnnic-table-cell', props.class)">
+    <slot />
+  </td>
+</template>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/unnnic' as *;
+
+.unnnic-table-cell {
+  vertical-align: middle;
+
+  padding: $unnnic-space-4 0;
+
+  &:not(:last-child) {
+    padding-right: $unnnic-space-4;
+  }
+}
+</style>

--- a/src/components/ui/table/TableHead.vue
+++ b/src/components/ui/table/TableHead.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue';
+import { cn } from '@/lib/utils';
+
+const props = defineProps<{
+  class?: HTMLAttributes['class'];
+}>();
+</script>
+
+<template>
+  <th :class="cn('unnnic-table-head', props.class)">
+    <slot />
+  </th>
+</template>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/unnnic' as *;
+
+.unnnic-table-head {
+  @include unnnic-font-caption-1;
+  color: $unnnic-color-fg-base;
+  text-align: left;
+  align-items: center;
+
+  pointer-events: none;
+}
+</style>

--- a/src/components/ui/table/TableHeader.vue
+++ b/src/components/ui/table/TableHeader.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue';
+import { cn } from '@/lib/utils';
+
+const props = defineProps<{
+  class?: HTMLAttributes['class'];
+}>();
+</script>
+
+<template>
+  <thead :class="cn('unnnic-table-header', props.class)">
+    <slot />
+  </thead>
+</template>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/unnnic' as *;
+
+.unnnic-table-header {
+  * {
+    padding-bottom: $unnnic-space-2;
+  }
+}
+</style>

--- a/src/components/ui/table/TableRow.vue
+++ b/src/components/ui/table/TableRow.vue
@@ -8,11 +8,15 @@ const props = defineProps<{
 }>();
 
 const attrs = useAttrs();
+
 const isClickable = computed(() => Boolean(attrs.onClick));
 </script>
 
 <template>
   <tr
+    :tabindex="isClickable ? 0 : undefined"
+    @keydown.enter="isClickable && $emit('click', $event)"
+    @keydown.space.prevent="isClickable && $emit('click', $event)"
     :class="
       cn(
         'unnnic-table-row',
@@ -24,6 +28,7 @@ const isClickable = computed(() => Boolean(attrs.onClick));
   >
     <slot />
   </tr>
+
 </template>
 
 <style lang="scss" scoped>

--- a/src/components/ui/table/TableRow.vue
+++ b/src/components/ui/table/TableRow.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue';
+import { computed, useAttrs } from 'vue';
+import { cn } from '@/lib/utils';
+
+const props = defineProps<{
+  class?: HTMLAttributes['class'];
+}>();
+
+const attrs = useAttrs();
+const isClickable = computed(() => Boolean(attrs.onClick));
+</script>
+
+<template>
+  <tr
+    :class="
+      cn(
+        'unnnic-table-row',
+        'transition-colors data-[state=selected]:bg-muted',
+        isClickable && 'cursor-pointer',
+        props.class,
+      )
+    "
+  >
+    <slot />
+  </tr>
+</template>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/unnnic' as *;
+
+.unnnic-table-row {
+  & > :first-child {
+    padding-left: $unnnic-space-3;
+  }
+
+  & > :last-child {
+    padding-right: $unnnic-space-3;
+  }
+
+  border-bottom: 1px solid $unnnic-color-border-base;
+
+  &:hover {
+    background-color: $unnnic-color-bg-soft;
+  }
+}
+</style>

--- a/src/components/ui/table/index.ts
+++ b/src/components/ui/table/index.ts
@@ -1,0 +1,6 @@
+export { default as Table } from './Table.vue';
+export { default as TableBody } from './TableBody.vue';
+export { default as TableCell } from './TableCell.vue';
+export { default as TableHead } from './TableHead.vue';
+export { default as TableHeader } from './TableHeader.vue';
+export { default as TableRow } from './TableRow.vue';

--- a/src/stories/Table.stories.js
+++ b/src/stories/Table.stories.js
@@ -2,11 +2,24 @@ import unnnicTable from '../components/Table/Table.vue';
 import unnnicTableRow from '../components/Table/TableRow.vue';
 import unnnicButton from '../components/Button/Button.vue';
 import unnnicCheckbox from '../components/Checkbox/Checkbox.vue';
+import {
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableCell,
+} from '@/components/ui/table';
+import UnnnicTag from '@/components/Tag/Tag.vue';
+import { action } from 'storybook/actions';
 
 export default {
   title: 'example/Table',
   component: unnnicTable,
-  argTypes: {},
+  argTypes: {
+    version: {
+      control: { type: 'select' },
+      options: ['1', '2'],
+    },
+  },
 };
 
 const Template = (args, { argTypes }) => ({
@@ -21,6 +34,7 @@ const Template = (args, { argTypes }) => ({
     <div>
       <unnnic-table
         v-bind="$props"
+        version="1"
         :items="table.items"
         :style="{ maxHeight: '280px', maxWidth: '800px', }"
       >
@@ -142,4 +156,63 @@ const Template = (args, { argTypes }) => ({
 });
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  version: '1',
+};
+
+export const Version2 = {
+  render: () => ({
+    components: {
+      unnnicTable,
+      unnnicTableRow,
+      TableHeader,
+      TableBody,
+      TableHead,
+      TableCell,
+      UnnnicTag,
+    },
+    setup() {
+      return {
+        onRowClick: action('click'),
+      };
+    },
+    template: `
+      <unnnic-table version="2">
+        <TableHeader>
+          <unnnic-table-row>
+            <TableHead>
+              Invoice
+            </TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Method</TableHead>
+            <TableHead>
+              Amount
+            </TableHead>
+          </unnnic-table-row>
+        </TableHeader>
+        <TableBody>
+          <unnnic-table-row>
+            <TableCell>
+              INV001
+            </TableCell>
+            <TableCell><UnnnicTag scheme="green" text="Paid" /></TableCell>
+            <TableCell>Credit Card</TableCell>
+            <TableCell>
+              $250.00
+            </TableCell>
+          </unnnic-table-row>
+          <unnnic-table-row @click="onRowClick">
+            <TableCell>
+              INV002
+            </TableCell>
+            <TableCell><UnnnicTag scheme="red" text="Pending" /></TableCell>
+            <TableCell>Bank Transfer</TableCell>
+            <TableCell>
+              $199.00
+            </TableCell>
+          </unnnic-table-row>
+        </TableBody>
+      </unnnic-table>
+    `,
+  }),
+};


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [ ] Tests
    - [ ] Other

### Motivation and Context

The existing `UnnnicTable` component lacked flexibility for more modern, composable table layouts. A new version of the table was needed that exposes semantic HTML table elements (`thead`, `tbody`, `tr`, `th`, `td`) as individual components, allowing greater control over structure and styling.

### Summary of Changes

A `version` prop has been added to `UnnnicTable` and `UnnnicTableRow`. When `version="2"` is set, the components delegate rendering to a new set of lower-level UI table primitives located in `src/components/ui/table/`:

- **`Table.vue`** – Wraps a native `<table>` element with base styles.
- **`TableHeader.vue`** – Wraps `<thead>`.
- **`TableBody.vue`** – Wraps `<tbody>`.
- **`TableRow.vue`** – Wraps `<tr>`, automatically applies a pointer cursor when an `onClick` handler is present.
- **`TableHead.vue`** – Wraps `<th>` with caption styling.
- **`TableCell.vue`** – Wraps `<td>` with spacing and alignment styles.

These new primitives are exported as `unnnicTableBody`, `unnnicTableCell`, `unnnicTableHead`, and `unnnicTableHeader` and are available under both the `unnnic*` and `Unnnic*` naming conventions.

A `Version2` Storybook story has been added to demonstrate the new composable table API, including clickable rows and tag-based cell content.



### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/61e0989f-0cf7-45d5-a543-79d3da4073c6.png)

