### PR TITLE
feat: Add optional footer slot at InputDatePicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 3.31.0 (2026-07-22)
+
+### Added
+
+- **InputDatePicker**: `#footer` slot rendered via `UnnnicPopoverFooter` when provided. The footer area is omitted when the slot is empty. Storybook story `WithFooter` added.
+
 # 3.30.0 (2026-07-08)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weni/unnnic-system",
-  "version": "3.30.0",
+  "version": "3.31.0",
   "type": "commonjs",
   "files": [
     "dist",

--- a/src/components/InputDatePicker/InputDatePicker.vue
+++ b/src/components/InputDatePicker/InputDatePicker.vue
@@ -42,13 +42,17 @@
           @change="emitSelectDate"
           @submit="changeDate"
         />
+
+        <UnnnicPopoverFooter v-if="hasFooterSlot">
+          <slot name="footer" />
+        </UnnnicPopoverFooter>
       </UnnnicPopoverContent>
     </UnnnicPopover>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, useSlots } from 'vue';
 import moment from 'moment';
 
 import UnnnicInput from '../Input/Input.vue';
@@ -56,12 +60,16 @@ import UnnnicDatePicker from '../DatePicker/DatePicker.vue';
 import {
   Popover as UnnnicPopover,
   PopoverContent as UnnnicPopoverContent,
+  PopoverFooter as UnnnicPopoverFooter,
   PopoverTrigger as UnnnicPopoverTrigger,
 } from '../ui/popover';
 
 defineOptions({
   name: 'UnnnicInputDatePicker',
 });
+
+const slots = useSlots();
+const hasFooterSlot = computed(() => Boolean(slots.footer));
 
 type DateRangeValue = {
   start: string | null;

--- a/src/components/InputDatePicker/__test__/InputDatePicker.spec.js
+++ b/src/components/InputDatePicker/__test__/InputDatePicker.spec.js
@@ -3,7 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import InputDatePicker from '../InputDatePicker.vue';
 
-const factory = (props = {}) =>
+const inlineSlot = { template: '<div><slot /></div>' };
+const portalStubs = {
+  PopoverPortal: inlineSlot,
+  PopoverContent: inlineSlot,
+};
+
+const factory = (props = {}, { slots = {}, stubs = {} } = {}) =>
   mount(InputDatePicker, {
     props: {
       modelValue: {
@@ -12,7 +18,11 @@ const factory = (props = {}) =>
       },
       ...props,
     },
+    slots,
     attachTo: document.body,
+    global: {
+      stubs,
+    },
   });
 
 describe('InputDatePicker.vue', () => {
@@ -162,5 +172,37 @@ describe('InputDatePicker.vue', () => {
     expect(rightWrapper.vm.popoverAlign).toBe('end');
 
     rightWrapper.unmount();
+  });
+
+  it('does not render PopoverFooter when the footer slot is empty', async () => {
+    wrapper.vm.isPopoverOpen = true;
+    await wrapper.vm.$nextTick();
+
+    expect(
+      wrapper.findComponent({ name: 'UnnnicPopoverFooter' }).exists(),
+    ).toBe(false);
+  });
+
+  it('renders the footer slot content inside PopoverFooter', async () => {
+    const withFooter = factory(
+      {},
+      {
+        slots: {
+          footer: '<p data-testid="custom-footer">Archive notice</p>',
+        },
+        stubs: portalStubs,
+      },
+    );
+
+    withFooter.vm.isPopoverOpen = true;
+    await withFooter.vm.$nextTick();
+
+    const footer = withFooter.findComponent({ name: 'UnnnicPopoverFooter' });
+    const customFooter = withFooter.find('[data-testid="custom-footer"]');
+
+    expect(footer.exists()).toBe(true);
+    expect(customFooter.text()).toBe('Archive notice');
+
+    withFooter.unmount();
   });
 });

--- a/src/stories/InputDatePicker.stories.js
+++ b/src/stories/InputDatePicker.stories.js
@@ -1,4 +1,5 @@
 import UnnnicInputDatePicker from '../components/InputDatePicker/InputDatePicker.vue';
+import UnnnicDisclaimer from '../components/Disclaimer/Disclaimer.vue';
 import moment from 'moment';
 export default {
   title: 'Form/InputDatePicker',
@@ -102,4 +103,53 @@ export const WithDisableShowOverwrittenValue = {
     size: 'sm',
     disableShowOverwrittenValue: true,
   },
+};
+
+export const WithFooter = {
+  args: {
+    size: 'sm',
+    next: true,
+    iconPosition: 'right',
+    fillW: true,
+    maxDate: moment().format('YYYY-MM-DD'),
+    minDate: moment().subtract(89, 'days').format('YYYY-MM-DD'),
+    options: [
+      { name: 'Last 7 days', id: 'last-7-days' },
+      { name: 'Last 14 days', id: 'last-14-days' },
+      { name: 'Last 30 days', id: 'last-30-days' },
+      { name: 'Last 90 days', id: 'last-90-days' },
+      { name: 'Current month', id: 'current-month' },
+      { name: 'Custom', id: 'custom' },
+    ],
+  },
+  render: (args) => ({
+    components: {
+      UnnnicInputDatePicker,
+      UnnnicDisclaimer,
+    },
+    setup() {
+      return { args };
+    },
+    data() {
+      return {
+        dates: {
+          start: null,
+          end: null,
+        },
+      };
+    },
+    template: `
+      <div style="max-width: 200px">
+        <pre>v-model: {{ dates }}</pre>
+        <UnnnicInputDatePicker v-bind="args" v-model="dates">
+          <template #footer>
+            <UnnnicDisclaimer
+              type="neutral"
+              description="Conversations older than 90 days are archived and can't be shown. To access them, contact support."
+            />
+          </template>
+        </UnnnicInputDatePicker>
+      </div>
+    `,
+  }),
 };


### PR DESCRIPTION
## Description

### Type of Change

```
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Tests
- [ ] Other
```

### Motivation and Context

There was no way to render additional content below the date picker calendar inside the popover. This change enables consumers to inject custom content into a dedicated footer area within the `InputDatePicker` popover.

### Summary of Changes

- Added a `footer` named slot to `InputDatePicker` that, when provided, renders a `UnnnicPopoverFooter` beneath the calendar content.
- The footer is conditionally rendered only when the `footer` slot is populated, using `useSlots` and a computed `hasFooterSlot` flag.
- Added tests to verify that `UnnnicPopoverFooter` is not rendered when the slot is empty, and that slot content is correctly rendered inside it when provided.
- Added a `WithFooter` Storybook story demonstrating the footer slot in use with a `UnnnicDisclaimer` component to communicate that conversations older than 90 days are archived.

### Demontration

![image.png](https://app.graphite.com/user-attachments/assets/387f4a85-54e1-442e-a7cd-160eedf12bf6.png)

