### PR TITLE
refactor(sanitize): remove maxLength parameter from sanitize functions for simplified usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 3.31.1 (2026-07-22)
+
+### Changed
+
+- **sanitize**: Removed the `maxLength` parameter and truncation logic from `sanitizeHtml`, `fullySanitize`, and `validateInput`. Sanitization no longer limits string length (default was `1000`).
+
 # 3.31.0 (2026-07-22)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weni/unnnic-system",
-  "version": "3.31.0",
+  "version": "3.31.1",
   "type": "commonjs",
   "files": [
     "dist",

--- a/src/utils/sanitize.js
+++ b/src/utils/sanitize.js
@@ -12,16 +12,10 @@ export function escapeHtml(input) {
  * Sanitizes HTML by removing disallowed tags and unsafe attributes.
  * @param {string} input
  * @param {Array<string>} allowedTags - List of allowed HTML tags.
- * @param {number} maxLength - Maximum length of the sanitized string.
  * @returns {string}
  */
-export function sanitizeHtml(input, allowedTags = [], maxLength = 1000) {
+export function sanitizeHtml(input, allowedTags = []) {
   if (typeof input !== 'string') return '';
-
-  // Limits text length
-  if (input.length > maxLength) {
-    input = input.substring(0, maxLength);
-  }
 
   // Decodes HTML entities (&lt;, &gt;, &amp;)
   input = escapeHtml(input);
@@ -41,13 +35,12 @@ export function sanitizeHtml(input, allowedTags = [], maxLength = 1000) {
  *
  * @param {string} input
  * @param {Array<string>} allowedTags - List of allowed HTML tags.
- * @param {number} maxLength - Maximum length of the sanitized string.
  * @returns {string}
  */
-export function fullySanitize(input, allowedTags = [], maxLength = 1000) {
+export function fullySanitize(input, allowedTags = []) {
   if (typeof input !== 'string') return '';
 
-  let sanitizedInput = sanitizeHtml(input, allowedTags, maxLength);
+  let sanitizedInput = sanitizeHtml(input, allowedTags);
 
   return escapeHtml(sanitizedInput);
 }
@@ -56,10 +49,9 @@ export function fullySanitize(input, allowedTags = [], maxLength = 1000) {
  * Validates and sanitizes input text.
  * @param {string} input - The input string to validate.
  * @param {Array<string>} allowedTags - List of allowed HTML tags.
- * @param {number} maxLength - Maximum length of the sanitized string.
  * @returns {{ isValid: boolean, sanitized: string, errors: string[] }} - Validation result.
  */
-export function validateInput(input, allowedTags = [], maxLength = 1000) {
+export function validateInput(input, allowedTags = []) {
   const errors = [];
 
   if (typeof input !== 'string') {
@@ -67,12 +59,7 @@ export function validateInput(input, allowedTags = [], maxLength = 1000) {
     return { isValid: false, sanitized: '', errors };
   }
 
-  if (input.length > maxLength) {
-    errors.push(`Input exceeds the maximum length of ${maxLength} characters.`);
-    input = input.substring(0, maxLength);
-  }
-
-  const sanitized = fullySanitize(input, allowedTags, maxLength);
+  const sanitized = fullySanitize(input, allowedTags);
 
   if (sanitized !== input) {
     errors.push(


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The `maxLength` parameter and its associated truncation logic in the sanitization utilities were redundant and added unnecessary complexity. Length validation and enforcement should be handled by the caller, not within the sanitization layer.

### Summary of Changes
- Removed the `maxLength` parameter from `sanitizeHtml`, `fullySanitize`, and `validateInput`
- Removed the input truncation logic (`input.substring(0, maxLength)`) from `sanitizeHtml` and `validateInput`
- Removed the max length error from the `validateInput` errors array